### PR TITLE
Support query generation when BaseSystem is not the immediate parent type

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -301,7 +301,15 @@ public static class QueryUtils
     {
         // Get BaseSystem class
         var classSymbol = classToMethod.Key as INamedTypeSymbol;
-        var parentSymbol = classSymbol.BaseType;
+
+        INamedTypeSymbol? parentSymbol = null;
+        var implementsUpdate = false;
+        var type = classSymbol;
+        while (type != null)
+        {
+            // Update was implemented by user, no need to do that by source generator.
+            if (type.MemberNames.Contains("Update"))
+                implementsUpdate = true;
 
         if (!parentSymbol.Name.Equals("BaseSystem")) return sb; // Ignore classes which do not derive from BaseSystem
         if (classSymbol.MemberNames.Contains("Update")) return sb; // Update was implemented by user, no need to do that by source generator. 

--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -311,9 +311,19 @@ public static class QueryUtils
             if (type.MemberNames.Contains("Update"))
                 implementsUpdate = true;
 
-        if (!parentSymbol.Name.Equals("BaseSystem")) return sb; // Ignore classes which do not derive from BaseSystem
-        if (classSymbol.MemberNames.Contains("Update")) return sb; // Update was implemented by user, no need to do that by source generator. 
-        
+            type = type.BaseType;
+
+            // Ignore classes which do not derive from BaseSystem
+            if (type?.Name == "BaseSystem")
+            {
+                parentSymbol = type;
+                break;
+            }
+        }
+
+        if (parentSymbol == null || implementsUpdate)
+            return sb;
+
         // Get generic of BaseSystem
         var typeSymbol = parentSymbol.TypeArguments[1];
 


### PR DESCRIPTION
In this example the query method would not get called:

```csharp
[UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
public abstract class GameSystem : BaseSystem<World, float>
{
    protected GameSystem(World world) : base(world)
    {
    }
}

public partial class TestSystem : GameSystem
{
    public TestSystem(World world) : base(world)
    {
    }

    [Query]
    [All<TestComponent>]
    public void Test(ref TestComponent component)
    {
        Console.WriteLine("test");
    }
}
```

The code now checks the inheritance tree for BaseSystem.
It also checks parents except for BaseSystem for an implementation of `Update()`.
It could be made to check for a non-sealed implementation in a parent and if found, call the base method at the start of its autogenerated `Update()` method, but that seemed out of scope.