### PR TITLE
Fixed generated class accessor

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -249,7 +249,7 @@ public static class QueryUtils
             using ArrayExtensions = CommunityToolkit.HighPerformance.ArrayExtensions;
             using Component = Arch.Core.Utils.Component;
             {{(!queryMethod.IsGlobalNamespace ? $"namespace {queryMethod.Namespace} {{" : "")}}
-                public {{staticModifier}} partial class {{queryMethod.ClassName}}{
+                {{staticModifier}} partial class {{queryMethod.ClassName}}{
                     
                     private {{staticModifier}} QueryDescription {{queryMethod.MethodName}}_QueryDescription = new QueryDescription{
                         All = {{allTypeArray}},


### PR DESCRIPTION
This fixes a small, but annoying, issue with the source generator where it really insists on making my classes public. By removing the accessor on the generated class, it will use whatever the original class is, be it internal, private, or public. 

This is useful when creating an engine of some sort where you use `internal` for internal systems that the game project should not be able to interact with.