### PR TITLE
Rename Update data parameter

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -357,7 +357,7 @@ public static class QueryUtils
                 public partial class {{baseSystem.Name}}{
                         
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    public override void Update(in {{baseSystem.GenericType.ToDisplayString()}} {{baseSystem.GenericType.Name.ToLower()}}){
+                    public override void Update(in {{baseSystem.GenericType.ToDisplayString()}} data){
                         {{methodCalls}}
                     }
                 }


### PR DESCRIPTION
This renames the generated Update method's data parameter from the type of `T` to just `data`. This fixes an issue where some type names will be interpreted as a type and thus not compile, like `double`. 

So basically, from

```cs
public override void Update(in double double) {}
```

to

```cs
public override void Update(in double data) {}
```