### PR TITLE
Fix global namespace breaking generated Update

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -330,7 +330,7 @@ public static class QueryUtils
         // Generate basesystem.
         var baseSystem = new BaseSystem
         {
-            Namespace = classSymbol.ContainingNamespace != null ? classSymbol.ContainingNamespace.ToString() : string.Empty,
+            Namespace = classSymbol.ContainingNamespace != null && !classSymbol.ContainingNamespace.IsGlobalNamespace ? classSymbol.ContainingNamespace.ToString() : string.Empty,
             GenericType = typeSymbol,
             GenericTypeNamespace = typeSymbol.ContainingNamespace.ToString(),
             Name = classSymbol.Name,


### PR DESCRIPTION
This fixes the generated Update file breaking when you're using the global/no namespace. Containing namespace seems to always exist, so I added a check to make sure it wasn't the global namespace.