### PR TITLE
Fixed static methods

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -200,7 +200,7 @@ public static class QueryUtils
             Namespace = methodSymbol.ContainingNamespace.ToString(),
             ClassName = className.Substring(className.LastIndexOf('.')+1),
             
-            IsStatic = methodSymbol.IsStatic,
+            IsStatic = methodSymbol.ContainingType.IsStatic,
             IsEntityQuery = entity,
             MethodName = methodSymbol.Name,
             


### PR DESCRIPTION
This is a simple fix that fixes static methods. 

Before you were checking the method's static status, but applied it to the class. A class could be non-static and still have a static method. So now we're checking the containing type instead of the method and only apply the static accessor when the class itself is static.