### PR TITLE
Added source generator for component registry

### DIFF
--- a/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
+++ b/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+        
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+        <PackageId>Arch.AOT.SourceGenerator</PackageId>
+        <Title>Arch.AOT.SourceGenerator</Title>
+        <Version>1.0.0</Version>
+        <Authors>genaray</Authors>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <Description>A source generator for arch.</Description>
+        <PackageReleaseNotes>
+            Added component registry generator.
+        </PackageReleaseNotes>
+        <PackageTags>c#;.net;.net6;.net7;ecs;game;entity;gamedev; game-development; game-engine; entity-component-system; arch;</PackageTags>
+
+        <PackageProjectUrl>https://github.com/genaray/Arch.Extended</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/genaray/Arch.Extended.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <IsPackable>true</IsPackable>
+
+        <LangVersion>11</LangVersion>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <Copyright>Apache2.0</Copyright>
+        <PackageLicenseUrl></PackageLicenseUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    </ItemGroup>
+
+</Project>

--- a/Arch.AOT.SourceGenerator/ComponentRegistryGenerator.cs
+++ b/Arch.AOT.SourceGenerator/ComponentRegistryGenerator.cs
@@ -1,0 +1,142 @@
+﻿using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Arch.SourceGen;
+
+/// <summary>
+///     Incremental generator that generates a class that adds all components to the ComponentRegistry.
+/// </summary>
+[Generator(LanguageNames.CSharp)]
+public sealed class ComponentRegistryGenerator : IIncrementalGenerator
+{
+	private const string ATTRIBUTE_TEMPLATE = @"using System;
+
+namespace Arch.Core
+{
+    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class ComponentAttribute : Attribute { }
+}";
+
+	private const string COMPONENT_REGISTRY_TEMPLATE = @"using System.Runtime.CompilerServices;
+using Arch.Core.Utils;
+
+namespace Arch.Generated
+{
+    internal static class GeneratedComponentRegistry
+    {
+        [ModuleInitializer]
+        public static void Initialize()
+        {
+%REPLACE%
+        }
+    }
+}";
+
+	public void Initialize(IncrementalGeneratorInitializationContext context)
+	{
+		// Register the attribute.
+		context.RegisterPostInitializationOutput(initializationContext =>
+		{
+			initializationContext.AddSource("Components.Attributes.g.cs", SourceText.From(ATTRIBUTE_TEMPLATE, Encoding.UTF8));
+		});
+
+		IncrementalValuesProvider<TypeDeclarationSyntax> provider = context.SyntaxProvider.CreateSyntaxProvider(
+			ShouldTypeBeRegistered,
+			GetMemberDeclarationsForSourceGen).Where(t => t.attributeFound).Select((t, _) => t.Item1);
+
+		context.RegisterSourceOutput(context.CompilationProvider.Combine(provider.Collect()),
+			(productionContext, tuple) => GenerateCode(productionContext, tuple.Left, tuple.Right));
+	}
+
+	/// <summary>
+	///     Determines if a node should be considered for code generation.
+	/// </summary>
+	/// <param name="node"></param>
+	/// <param name="cancellationToken"></param>
+	/// <returns></returns>
+	private static bool ShouldTypeBeRegistered(SyntaxNode node, CancellationToken cancellationToken)
+	{
+		if (node is not TypeDeclarationSyntax typeDeclarationSyntax)
+		{
+			return false;
+		}
+
+		return typeDeclarationSyntax.AttributeLists.Count != 0;
+	}
+
+	/// <summary>
+	///     Make sure the type is annotated with the Component attribute.
+	/// </summary>
+	/// <param name="context"></param>
+	/// <param name="cancellationToken"></param>
+	/// <returns></returns>
+	private static (TypeDeclarationSyntax, bool attributeFound) GetMemberDeclarationsForSourceGen(GeneratorSyntaxContext context,
+		CancellationToken cancellationToken)
+	{
+		TypeDeclarationSyntax typeDeclarationSyntax = (TypeDeclarationSyntax) context.Node;
+
+		// Stop here if we can't get the type symbol for some reason.
+		if (context.SemanticModel.GetDeclaredSymbol(typeDeclarationSyntax) is not ITypeSymbol symbol)
+		{
+			return (typeDeclarationSyntax, false);
+		}
+
+		// Go through all the attributes.
+		foreach (AttributeData? attributeData in symbol.GetAttributes())
+		{
+			if (attributeData.AttributeClass is null)
+			{
+				continue;
+			}
+
+			// If the attribute is the Component attribute, we can stop here and return true.
+			if (string.Equals(attributeData.AttributeClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), "global::Arch.Core.ComponentAttribute",
+				    StringComparison.Ordinal))
+			{
+				return (typeDeclarationSyntax, true);
+			}
+		}
+
+		// No attribute found, return false.
+		return (typeDeclarationSyntax, false);
+	}
+
+	private static void GenerateCode(SourceProductionContext productionContext, Compilation compilation, ImmutableArray<TypeDeclarationSyntax> typeList)
+	{
+		StringBuilder sb = new StringBuilder();
+
+		foreach (TypeDeclarationSyntax? type in typeList)
+		{
+			// Get the symbol for the type.
+			ISymbol? symbol = compilation.GetSemanticModel(type.SyntaxTree).GetDeclaredSymbol(type);
+
+			// If the symbol is not a type symbol, we can't do anything with it.
+			if (symbol is not ITypeSymbol typeSymbol)
+			{
+				continue;
+			}
+
+			// Check if there are any fields in the type.
+			bool hasZeroFields = true;
+			foreach (ISymbol? member in typeSymbol.GetMembers())
+			{
+				if (member is IFieldSymbol)
+				{
+					hasZeroFields = false;
+					break;
+				}
+			}
+
+			string typeName = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+			string hasZeroFieldsString = hasZeroFields ? "true" : "false";
+			string size = typeSymbol.IsValueType ? $"Unsafe.SizeOf<{typeName}>()" : "IntPtr.Size";
+
+			sb.AppendLine($"\t\t\tComponentRegistry.Add(new ComponentType(ComponentRegistry.Size + 1, typeof({typeName}), {size}, {hasZeroFieldsString}));");
+		}
+
+		productionContext.AddSource("GeneratedComponentRegistry.g.cs", COMPONENT_REGISTRY_TEMPLATE.Replace("%REPLACE%", sb.ToString().TrimEnd()));
+	}
+}

--- a/Arch.AOT.SourceGenerator/ComponentType.cs
+++ b/Arch.AOT.SourceGenerator/ComponentType.cs
@@ -1,0 +1,27 @@
+﻿namespace Arch.SourceGen;
+
+/// <summary>
+///     Represents ComponentType for use in the generated code.
+/// </summary>
+public struct ComponentType
+{
+	/// <summary>
+	///     The type name of the component.
+	/// </summary>
+	public string TypeName { get; }
+	/// <summary>
+	///     If the component has zero fields.
+	/// </summary>
+	public bool IsZeroSize { get; }
+	/// <summary>
+	///     If the component is a value type.
+	/// </summary>
+	public bool IsValueType { get; }
+
+	public ComponentType(string typeName, bool isZeroSize, bool isValueType)
+	{
+		TypeName = typeName;
+		IsZeroSize = isZeroSize;
+		IsValueType = isValueType;
+	}
+}

--- a/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -1,0 +1,56 @@
+﻿using System.Text;
+
+namespace Arch.SourceGen.Extensions;
+
+public static class StringBuilderExtensions
+{
+	/// <summary>
+	///     Appends the component types to the string builder in the form of a generated class.
+	/// </summary>
+	/// <param name="sb">The target string builder.</param>
+	/// <param name="componentTypes">The types to append.</param>
+	/// <returns></returns>
+	public static StringBuilder AppendComponentTypes(this StringBuilder sb, IList<ComponentType> componentTypes)
+	{
+		sb.AppendLine(@"using System.Runtime.CompilerServices;
+using Arch.Core.Utils;
+
+namespace Arch.Generated
+{
+    internal static class GeneratedComponentRegistry
+    {
+        [ModuleInitializer]
+        public static void Initialize()
+        {");
+
+		for (int i = 0; i < componentTypes.Count; i++)
+		{
+			ComponentType componentType = componentTypes[i];
+			sb.AppendComponentType(ref componentType);
+		}
+
+		sb.Append(@"
+		}
+	}
+}");
+
+		return sb;
+	}
+
+	/// <summary>
+	///     Appends a single component type to the string builder as a new line.
+	/// </summary>
+	/// <param name="sb">The string builder.</param>
+	/// <param name="componentType">The component type to add.</param>
+	/// <returns></returns>
+	public static StringBuilder AppendComponentType(this StringBuilder sb, ref ComponentType componentType)
+	{
+		string hasZeroFieldsString = componentType.IsZeroSize ? "true" : "false";
+		string size = componentType.IsValueType ? $"Unsafe.SizeOf<{componentType.TypeName}>()" : "IntPtr.Size";
+
+		sb.AppendLine(
+			$"\t\t\tComponentRegistry.Add(new ComponentType(ComponentRegistry.Size + 1, typeof({componentType.TypeName}), {size}, {hasZeroFieldsString}));");
+
+		return sb;
+	}
+}

--- a/Arch.Extended.sln
+++ b/Arch.Extended.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arch.Relationships", "Arch.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arch.Relationships.Tests", "Arch.Relationships.Tests\Arch.Relationships.Tests.csproj", "{EDAFD1B8-5FC3-4002-B2AD-5B976B809D1C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arch.AOT.SourceGenerator", "Arch.AOT.SourceGenerator\Arch.AOT.SourceGenerator.csproj", "{0A00966E-A0B2-4BBA-B0B4-3F24D196C7A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,5 +68,9 @@ Global
 		{EDAFD1B8-5FC3-4002-B2AD-5B976B809D1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EDAFD1B8-5FC3-4002-B2AD-5B976B809D1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EDAFD1B8-5FC3-4002-B2AD-5B976B809D1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A00966E-A0B2-4BBA-B0B4-3F24D196C7A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A00966E-A0B2-4BBA-B0B4-3F24D196C7A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A00966E-A0B2-4BBA-B0B4-3F24D196C7A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A00966E-A0B2-4BBA-B0B4-3F24D196C7A3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds a source generator that creates a `[Component]` attribute for you and if you mark your components with it, it will automatically register them in the component registry on application launch. This fixes some AOT issues.

This new package should probably be deployed as it's own NuGet package