### PR TITLE
Add support for ArrayRegistry

### DIFF
--- a/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -57,6 +57,7 @@ public static class StringBuilderExtensions
 		var size = componentType.IsValueType ? $"Unsafe.SizeOf<{componentType.TypeName}>()" : "IntPtr.Size";
 
 		sb.AppendLine($"ComponentRegistry.Add(new ComponentType(ComponentRegistry.Size + 1, typeof({componentType.TypeName}), {size}, {hasZeroFieldsString}));");
+		sb.AppendLine($"ArrayRegistry.Add<{componentType.TypeName}>();");
 		return sb;
 	}
 }


### PR DESCRIPTION
This simple PR makes the AOT generator use the new ArrayRegistry recently introduced in Arch. This will complete the Native AOT support!