### PR TITLE
Ensure Unity publishing works without disrupting other targets

### DIFF
--- a/Arch.LowLevel/Arch.LowLevel.csproj
+++ b/Arch.LowLevel/Arch.LowLevel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net7.0; net6.0; netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Arch.LowLevel/Arch.LowLevel.csproj
+++ b/Arch.LowLevel/Arch.LowLevel.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net7.0; net6.0; netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Arch.Persistence/Arch.Persistence.csproj
+++ b/Arch.Persistence/Arch.Persistence.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>
         <LangVersion>11</LangVersion>
 

--- a/Arch.Persistence/Arch.Persistence.csproj
+++ b/Arch.Persistence/Arch.Persistence.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>
         <LangVersion>11</LangVersion>
 

--- a/Arch.Relationships/Arch.Relationships.csproj
+++ b/Arch.Relationships/Arch.Relationships.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
         <LangVersion>11</LangVersion>
 

--- a/Arch.Relationships/Arch.Relationships.csproj
+++ b/Arch.Relationships/Arch.Relationships.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
         <LangVersion>11</LangVersion>
 

--- a/Arch.System/Arch.System.csproj
+++ b/Arch.System/Arch.System.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net7.0; net6.0; netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         

--- a/Arch.System/Arch.System.csproj
+++ b/Arch.System/Arch.System.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
         <TargetFrameworks>net7.0; net6.0; netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,8 +3,6 @@
           DependsOnTargets="Publish"
           Condition="'$(UnityPublish.Contains(true))'">
     <PropertyGroup>
-      <TargetFramework>netstandard2.1</TargetFramework>
-      <TargetFrameworks>netstandard2.1</TargetFrameworks>
       <Configuration>Release</Configuration>
       <UseAppHost>false</UseAppHost>
       <SatelliteResourceLanguages>en</SatelliteResourceLanguages>

--- a/scripts/UnityPublish.sh
+++ b/scripts/UnityPublish.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 # Publishes Unity release to dist/Assemblies using only netstandard2.0 and netstandard2.1
-# Does NOT include extensions dependent on source generation
 #########################################################################################
 
 dotnet restore
 
 assemblyDir="`pwd`/dist/Assemblies"
 
+rm -rf "${assemblyDir}"
+
 mkdir -p "${assemblyDir}"
 
-dotnet msbuild /t:Unity -p:PublishDir="${assemblyDir}"
+dotnet msbuild /t:Unity \
+    -p:PublishDir="${assemblyDir}" \
+    -p:TargetFramework=netstandard2.1 \
+    -p:TargetFrameworks=netstandard2.1 \
+    -p:TargetFrameworkVersion=v2.1


### PR DESCRIPTION
This pull request fixes this problem: https://github.com/genaray/Arch/discussions/143#discussioncomment-7159775.

(However, note that tests for Arch.Extended were already failing before the Unity publishing changes were merged.)

Now the `TargetFramework` for projects that otherwise didn't have it is set to `net7.0` which will prevent the tests from failing (for that reason). `TargetFramework`, `TargetFrameworks` and `TargetFrameworkVersion` are also now forced in the `UnityPublish.sh` script as arguments, because it 100% reliably overwrites whereas putting them in `Directory.Build.targets` apparently didn't. I'm not a fan of MSBuild.

I'm additionally ensuring that any previously published assemblies are deleted before new ones are generated again just to be safe. We don't want old ones to gunk up the directory. And I removed some confusing language about codegen from the shell script. Sorry for all the hassle with this. It's a lot of trial and error wrangling this build system to comply with reason.

**Edit:** Sister PR: https://github.com/genaray/Arch/pull/152