### PR TITLE
Improved Test Coverage & Assorted Bug Fixes

### DIFF
--- a/Arch.LowLevel.Tests/UnsafeListTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeListTest.cs
@@ -10,7 +10,7 @@ public class UnsafeListTest
 {
     
     /// <summary>
-    ///     Checks if <see cref="UnsafeList{T}"/> is capable of adding itemss.
+    ///     Checks if <see cref="UnsafeList{T}"/> is capable of adding items.
     /// </summary>
     [Test]
     public void UnsafeListAdd()
@@ -22,7 +22,94 @@ public class UnsafeListTest
         
         That(list.Count, Is.EqualTo(3));
     }
-    
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeList{T}"/> is capable of being copied to an array.
+    /// </summary>
+    [Test]
+    public void UnsafeListCopyTo()
+    {
+        using var list = new UnsafeList<int>(8);
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+
+        var arr = new int[10];
+
+        // Basic copy into the array
+        list.CopyTo(arr, 3);
+        CollectionAssert.AreEqual(new[] { 0, 0, 0, 1, 2, 3, 0, 0, 0, 0 }, arr);
+
+        // Copy into a bad index
+        Throws<IndexOutOfRangeException>(() => { list.CopyTo(arr, -3); });
+        Throws<IndexOutOfRangeException>(() => { list.CopyTo(arr, arr.Length + 1); });
+
+        // Copy into an index near the end, so there's not enough space
+        Throws<ArgumentException>(() => list.CopyTo(arr, 8));
+
+        // Check that copying into an array from an empty list does nothing
+        list.Clear();
+        var arr2 = arr.ToArray();
+        list.CopyTo(arr, 0);
+        CollectionAssert.AreEqual(arr, arr2);
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeList{T}"/> is capable of being cleared.
+    /// </summary>
+    [Test]
+    public void UnsafeListClear()
+    {
+        using var list = new UnsafeList<int>(8);
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+
+        list.Clear();
+        That(list, Is.Empty);
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeList{T}"/> is can be converted into a span.
+    /// </summary>
+    [Test]
+    public void UnsafeListAsSpan()
+    {
+        using var list = new UnsafeList<int>(8);
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, list.AsSpan().ToArray());
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeList{T}"/> equality works as expected
+    /// </summary>
+    [Test]
+    public void UnsafeListEquality()
+    {
+        using var list1 = new UnsafeList<int>(8);
+        list1.Add(1);
+        list1.Add(2);
+        list1.Add(3);
+
+        using var list2 = new UnsafeList<int>(8);
+        list2.Add(1);
+        list2.Add(2);
+        list2.Add(3);
+
+        That(list1 == list2, Is.False);
+        That(list1 != list2, Is.True);
+
+        var list1a = list1;
+        That(list1 == list1a, Is.True);
+        That(list1 != list1a, Is.False);
+
+        That(list1.Equals((object)list2), Is.False);
+        That(list1.Equals((object)list1), Is.True);
+    }
+
     /// <summary>
     ///     Checks if <see cref="UnsafeList{T}"/> is capable of adding items at a given index.
     /// </summary>

--- a/Arch.LowLevel.Tests/UnsafeListTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeListTest.cs
@@ -231,7 +231,6 @@ public class UnsafeListTest
         }
     }
 
-    //todo:include this
     [Test]
     public void UnsafeListFuzz()
     {

--- a/Arch.LowLevel.Tests/UnsafeListTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeListTest.cs
@@ -207,6 +207,34 @@ public class UnsafeListTest
     ///     Checks if the unsafe list enumerator can be reset
     /// </summary>
     [Test]
+    public void UnsafeListAsIListEnumeratorReset()
+    {
+        using var list = new UnsafeList<int>(8);
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+
+        using var enumerator = ((IList<int>)list).GetEnumerator();
+
+        That(enumerator.MoveNext(), Is.True);
+        That(enumerator.Current, Is.EqualTo(1));
+        That(enumerator.MoveNext(), Is.True);
+        That(enumerator.Current, Is.EqualTo(2));
+
+        enumerator.Reset();
+
+        var count = 1;
+        foreach (var item in list)
+        {
+            That(count, Is.EqualTo(item));
+            count++;
+        }
+    }
+
+    /// <summary>
+    ///     Checks if the unsafe list enumerator can be reset
+    /// </summary>
+    [Test]
     public void UnsafeListEnumeratorReset()
     {
         using var list = new UnsafeList<int>(8);

--- a/Arch.LowLevel.Tests/UnsafeQueueTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeQueueTest.cs
@@ -7,9 +7,9 @@ using static NUnit.Framework.Assert;
 [TestFixture]
 public class UnsafeQueueTest
 {
-   
+
     /// <summary>
-    ///     Checks if <see cref="UnsafeStack{T}"/> is capable of adding itemss.
+    ///     Checks if <see cref="UnsafeQueue{T}"/> is capable of adding itemss.
     /// </summary>
     [Test]
     public void UnsafeQueueEnqueue()
@@ -22,9 +22,9 @@ public class UnsafeQueueTest
         That(queue, Has.Count.EqualTo(20));
         That(queue.Peek(), Is.EqualTo(0));
     }
-    
+
     /// <summary>
-    ///     Checks if <see cref="UnsafeStack{T}"/> is capable of peeking itemss.
+    ///     Checks if <see cref="UnsafeQueue{T}"/> is capable of peeking itemss.
     /// </summary>
     [Test]
     public void UnsafeQueuePeek()
@@ -37,9 +37,9 @@ public class UnsafeQueueTest
         queue.Enqueue(3);
         That(queue.Peek(), Is.EqualTo(1));
     }
-    
+
     /// <summary>
-    ///     Checks if <see cref="UnsafeStack{T}"/> is capable of popping itemss.
+    ///     Checks if <see cref="UnsafeQueue{T}"/> is capable of popping itemss.
     /// </summary>
     [Test]
     public void UnsafeQueueDequeue()
@@ -78,9 +78,9 @@ public class UnsafeQueueTest
 
         That(queue, Is.Empty);
     }
-    
+
     /// <summary>
-    ///     Checks if <see cref="UnsafeList{T}"/> is capable of iterating with its enumerators.
+    ///     Checks if <see cref="UnsafeQueue{T}"/> is capable of iterating with its enumerators.
     /// </summary>
     [Test]
     public void UnsafeQueueEnumerator()
@@ -99,6 +99,9 @@ public class UnsafeQueueTest
         That(count, Is.EqualTo(3));
     }
 
+    /// <summary>
+    ///      Checks if <see cref="UnsafeQueue{T}"/> can be constructed with invalid parameters.
+    /// </summary>
     [Test]
     public void UnsafeQueueInvalidConstruction()
     {
@@ -106,5 +109,42 @@ public class UnsafeQueueTest
         {
             new UnsafeQueue<int>(-8);
         });
+    }
+
+    /// <summary>
+    ///      Checks if <see cref="UnsafeQueue{T}"/> EnsureCapacity functions correctly.
+    /// </summary>
+    [Test]
+    public void UnsafeQueueEnsureCapacity()
+    {
+        using var queue = new UnsafeQueue<int>(8);
+
+        That(queue.Capacity, Is.AtLeast(8));
+
+        queue.EnsureCapacity(20);
+        That(queue.Capacity, Is.AtLeast(20));
+
+        queue.EnsureCapacity(10);
+        That(queue.Capacity, Is.AtLeast(20));
+    }
+
+    /// <summary>
+    ///      Checks if <see cref="UnsafeQueue{T}"/> TrimExcess removes all excess capacity.
+    /// </summary>
+    [Test]
+    public void UnsafeQueueTrimExcess()
+    {
+        using var queue = new UnsafeQueue<int>(8);
+        for (var i = 0; i < 4; i++)
+            queue.Enqueue(i);
+
+        That(queue.Capacity, Is.AtLeast(8));
+
+        queue.EnsureCapacity(20);
+        That(queue.Capacity, Is.AtLeast(20));
+
+        queue.TrimExcess();
+
+        That(queue.Capacity, Is.EqualTo(4));
     }
 }

--- a/Arch.LowLevel.Tests/UnsafeQueueTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeQueueTest.cs
@@ -9,7 +9,7 @@ public class UnsafeQueueTest
 {
 
     /// <summary>
-    ///     Checks if <see cref="UnsafeQueue{T}"/> is capable of adding itemss.
+    ///     Checks if <see cref="UnsafeQueue{T}"/> is capable of adding items.
     /// </summary>
     [Test]
     public void UnsafeQueueEnqueue()
@@ -21,6 +21,22 @@ public class UnsafeQueueTest
         
         That(queue, Has.Count.EqualTo(20));
         That(queue.Peek(), Is.EqualTo(0));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeQueue{T}"/> is capable of being converted into a span.
+    /// </summary>
+    [Test]
+    public void UnsafeQueueAsSpan()
+    {
+        using var queue = new UnsafeQueue<int>(8);
+
+        for (var i = 0; i < 9; i++)
+            queue.Enqueue(i);
+
+        var span = queue.AsSpan();
+
+        CollectionAssert.AreEqual(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 }, span.ToArray());
     }
 
     /// <summary>

--- a/Arch.LowLevel.Tests/UnsafeQueueTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeQueueTest.cs
@@ -14,13 +14,13 @@ public class UnsafeQueueTest
     [Test]
     public void UnsafeQueueEnqueue()
     {
-        using var stack = new UnsafeQueue<int>(8);
-        stack.Enqueue(1);
-        stack.Enqueue(2);
-        stack.Enqueue(3);
+        using var queue = new UnsafeQueue<int>(8);
+
+        for (var i = 0; i < 20; i++)
+            queue.Enqueue(i);
         
-        That(stack.Count, Is.EqualTo(3));
-        That(stack.Peek(), Is.EqualTo(1));
+        That(queue, Has.Count.EqualTo(20));
+        That(queue.Peek(), Is.EqualTo(0));
     }
     
     /// <summary>
@@ -29,13 +29,13 @@ public class UnsafeQueueTest
     [Test]
     public void UnsafeQueuePeek()
     {
-        using var stack = new UnsafeQueue<int>(8);
-        stack.Enqueue(1);
-        stack.Enqueue(2);
+        using var queue = new UnsafeQueue<int>(8);
+        queue.Enqueue(1);
+        queue.Enqueue(2);
 
-        That(stack.Peek(), Is.EqualTo(1));
-        stack.Enqueue(3);
-        That(stack.Peek(), Is.EqualTo(1));
+        That(queue.Peek(), Is.EqualTo(1));
+        queue.Enqueue(3);
+        That(queue.Peek(), Is.EqualTo(1));
     }
     
     /// <summary>
@@ -44,13 +44,39 @@ public class UnsafeQueueTest
     [Test]
     public void UnsafeQueueDequeue()
     {
-        using var stack = new UnsafeQueue<int>(8);
-        stack.Enqueue(1);
-        stack.Enqueue(2);
-        stack.Enqueue(3);
+        using var queue = new UnsafeQueue<int>(8);
+        queue.Enqueue(1);
+        queue.Enqueue(2);
+        queue.Enqueue(3);
         
-        That(stack.Dequeue(), Is.EqualTo(1));
-        That(stack.Dequeue(), Is.EqualTo(2));
+        That(queue.Dequeue(), Is.EqualTo(1));
+        That(queue.Dequeue(), Is.EqualTo(2));
+        That(queue.Dequeue(), Is.EqualTo(3));
+
+        Throws<InvalidOperationException>(() =>
+        {
+            queue.Dequeue();
+        });
+
+        Throws<InvalidOperationException>(() =>
+        {
+            queue.Peek();
+        });
+    }
+
+    [Test]
+    public void UnsafeQueueClear()
+    {
+        using var queue = new UnsafeQueue<int>(8);
+
+        for (var i = 0; i < 20; i++)
+            queue.Enqueue(i);
+
+        That(queue, Has.Count.EqualTo(20));
+
+        queue.Clear();
+
+        That(queue, Is.Empty);
     }
     
     /// <summary>
@@ -59,17 +85,26 @@ public class UnsafeQueueTest
     [Test]
     public void UnsafeQueueEnumerator()
     {
-        using var stack = new UnsafeQueue<int>(8);
-        stack.Enqueue(1);
-        stack.Enqueue(2);
-        stack.Enqueue(3);
+        using var queue = new UnsafeQueue<int>(8);
+        queue.Enqueue(1);
+        queue.Enqueue(2);
+        queue.Enqueue(3);
 
         // Ref iterator
         var count = 0;
-        foreach (ref var item in stack)
+        foreach (ref var item in queue)
         {
             count++;
         }
         That(count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void UnsafeQueueInvalidConstruction()
+    {
+        Throws<ArgumentOutOfRangeException>(() =>
+        {
+            new UnsafeQueue<int>(-8);
+        });
     }
 }

--- a/Arch.LowLevel.Tests/UnsafeStackTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeStackTest.cs
@@ -72,4 +72,32 @@ public class UnsafeStackTest
         }
         That(count, Is.EqualTo(3));
     }
+
+    /// <summary>
+    ///     Checks if the stack enumerator can be reset
+    /// </summary>
+    [Test]
+    public void UnsafeStackEnumeratorReset()
+    {
+        using var stack = new UnsafeStack<int>(8);
+        stack.Push(1);
+        stack.Push(2);
+        stack.Push(3);
+
+        var enumerator = stack.GetEnumerator();
+
+        True(enumerator.MoveNext());
+        That(enumerator.Current, Is.EqualTo(3));
+        True(enumerator.MoveNext());
+        That(enumerator.Current, Is.EqualTo(2));
+
+        enumerator.Reset();
+
+        var count = 3;
+        foreach (var item in stack)
+        {
+            That(count, Is.EqualTo(item));
+            count--;
+        }
+    }
 }

--- a/Arch.LowLevel.Tests/UnsafeStackTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeStackTest.cs
@@ -1,4 +1,6 @@
-﻿namespace Arch.LowLevel.Tests;
+﻿using System.Collections;
+
+namespace Arch.LowLevel.Tests;
 using static NUnit.Framework.Assert;
 
 /// <summary>
@@ -85,6 +87,55 @@ public class UnsafeStackTest
         stack.Push(3);
 
         var enumerator = stack.GetEnumerator();
+
+        True(enumerator.MoveNext());
+        That(enumerator.Current, Is.EqualTo(3));
+        True(enumerator.MoveNext());
+        That(enumerator.Current, Is.EqualTo(2));
+
+        enumerator.Reset();
+
+        var count = 3;
+        foreach (var item in stack)
+        {
+            That(count, Is.EqualTo(item));
+            count--;
+        }
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeList{T}"/> is capable of iterating with its enumerators.
+    /// </summary>
+    [Test]
+    public void UnsafeStackIEnumerableTEnumerator()
+    {
+        using var stack = new UnsafeStack<int>(8);
+        stack.Push(1);
+        stack.Push(2);
+        stack.Push(3);
+
+        var enumerable = (IEnumerable<int>)stack;
+
+        var count = 0;
+        foreach (var item in enumerable)
+        {
+            count++;
+        }
+        That(count, Is.EqualTo(3));
+    }
+
+    /// <summary>
+    ///     Checks if the stack enumerator can be reset
+    /// </summary>
+    [Test]
+    public void UnsafeStackIEnumerableEnumeratorReset()
+    {
+        using var stack = new UnsafeStack<int>(8);
+        stack.Push(1);
+        stack.Push(2);
+        stack.Push(3);
+
+        var enumerator = ((IEnumerable)stack).GetEnumerator();
 
         True(enumerator.MoveNext());
         That(enumerator.Current, Is.EqualTo(3));

--- a/Arch.LowLevel/Resources.cs
+++ b/Arch.LowLevel/Resources.cs
@@ -166,5 +166,6 @@ public sealed class Resources<T> : IDisposable
     {
         _array = null;
         _ids = null;
+        Count = 0;
     }
 }

--- a/Arch.LowLevel/UnsafeList.cs
+++ b/Arch.LowLevel/UnsafeList.cs
@@ -209,7 +209,13 @@ public unsafe struct UnsafeList<T> : IList<T>, IDisposable where T : unmanaged
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void CopyTo(T[] array, int arrayIndex)
     {
-        if(Count == 0) return;
+        if (Count == 0)
+            return;
+        if (arrayIndex < 0 || arrayIndex >= array.Length)
+            throw new IndexOutOfRangeException("Index must be 0 <= index <= array.Length");
+        if (arrayIndex + Count > array.Length)
+            throw new ArgumentException("Destination array was not long enough. Check the destination index, length, and the array's lower bounds.", nameof(arrayIndex));
+
         fixed(T* arrayPtr = array)
         {
             Buffer.MemoryCopy(_array, arrayPtr+arrayIndex, array.Length * sizeof(T), Count * sizeof(T));

--- a/Arch.LowLevel/UnsafeList.cs
+++ b/Arch.LowLevel/UnsafeList.cs
@@ -104,19 +104,23 @@ public unsafe struct UnsafeList<T> : IList<T>, IDisposable where T : unmanaged
         // Inserting to end of the list is legal.
         if ((uint)index > (uint)Count)
         {
-            throw new ArgumentOutOfRangeException(); 
+            throw new ArgumentOutOfRangeException(nameof(index)); 
         }
         
         // Resize if the list is actually full
-        if(Capacity == Count+1) 
+        if (Capacity == Count) 
         {
             EnsureCapacity(Capacity + 1);
         }
 
-        if(index < Count) 
+        if (index < Count)
         {
-            //Buffer.MemoryCopy(_array+index, _array+index+1,Capacity-Count,Capacity-Count);
-            UnsafeArray.Copy(ref _array, index, ref _array, index+1, Capacity-Count);
+            //var span = _array.AsSpan();
+            //var src = span.Slice(index, Count - index);
+            //var dst = span.Slice(index + 1, src.Length);
+            //src.CopyTo(dst);
+
+            UnsafeArray.Copy(ref _array, index, ref _array, index + 1, Count - index);
         }
         
         _array[index] = item;
@@ -134,7 +138,7 @@ public unsafe struct UnsafeList<T> : IList<T>, IDisposable where T : unmanaged
     {
         if ((uint)index > (uint)Count) 
         {
-            throw new ArgumentOutOfRangeException();
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
         
         Count--;

--- a/Arch.LowLevel/UnsafeQueue.cs
+++ b/Arch.LowLevel/UnsafeQueue.cs
@@ -113,7 +113,7 @@ public unsafe struct UnsafeQueue<T> : IEnumerable<T>, IDisposable where T : unma
     public void TrimExcess()
     {
         var newCapacity = _count;
-        EnsureCapacity(newCapacity, true);
+        SetCapacity(newCapacity);
     }
 
     /// <summary>
@@ -124,29 +124,25 @@ public unsafe struct UnsafeQueue<T> : IEnumerable<T>, IDisposable where T : unma
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void EnsureCapacity(int newCapacity)
     {
-        EnsureCapacity(newCapacity, false);
+        if (newCapacity <= _capacity)
+        {
+            return;
+        }
+
+        SetCapacity(newCapacity);
     }
 
     /// <summary>
     ///     Ensures the capacity of this instance. 
     /// </summary>
     /// <param name="newCapacity">The new capacity.</param>
-    /// <param name="allowShrinking">Indicates if the new capacity may be smaller than current capacity</param>
     /// <exception cref="ArgumentException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void EnsureCapacity(int newCapacity, bool allowShrinking)
+    private void SetCapacity(int newCapacity)
     {
-        if (allowShrinking)
+        if (newCapacity < _count)
         {
-            if (newCapacity < _count)
-                throw new ArgumentOutOfRangeException(nameof(newCapacity), "newCapacity cannot be smaller than _count");
-        }
-        else
-        {
-            if (newCapacity <= _capacity)
-            {
-                return;
-            }
+            throw new ArgumentOutOfRangeException(nameof(newCapacity), "newCapacity cannot be smaller than _count");
         }
 
         var newBuffer = new UnsafeArray<T>(newCapacity);

--- a/Arch.LowLevel/UnsafeQueue.cs
+++ b/Arch.LowLevel/UnsafeQueue.cs
@@ -113,7 +113,7 @@ public unsafe struct UnsafeQueue<T> : IEnumerable<T>, IDisposable where T : unma
     public void TrimExcess()
     {
         var newCapacity = _count;
-        EnsureCapacity(newCapacity);
+        EnsureCapacity(newCapacity, true);
     }
 
     /// <summary>
@@ -124,9 +124,29 @@ public unsafe struct UnsafeQueue<T> : IEnumerable<T>, IDisposable where T : unma
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void EnsureCapacity(int newCapacity)
     {
-        if (newCapacity <= _capacity)
+        EnsureCapacity(newCapacity, false);
+    }
+
+    /// <summary>
+    ///     Ensures the capacity of this instance. 
+    /// </summary>
+    /// <param name="newCapacity">The new capacity.</param>
+    /// <param name="allowShrinking">Indicates if the new capacity may be smaller than current capacity</param>
+    /// <exception cref="ArgumentException"></exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureCapacity(int newCapacity, bool allowShrinking)
+    {
+        if (allowShrinking)
         {
-            return;
+            if (newCapacity < _count)
+                throw new ArgumentOutOfRangeException(nameof(newCapacity), "newCapacity cannot be smaller than _count");
+        }
+        else
+        {
+            if (newCapacity <= _capacity)
+            {
+                return;
+            }
         }
 
         var newBuffer = new UnsafeArray<T>(newCapacity);

--- a/Arch.LowLevel/UnsafeQueue.cs
+++ b/Arch.LowLevel/UnsafeQueue.cs
@@ -19,6 +19,11 @@ public unsafe struct UnsafeQueue<T> : IEnumerable<T>, IDisposable where T : unma
     private int _frontIndex;
     private int _count;
 
+    /// <summary>
+    ///     Creates an instance of the <see cref="UnsafeQueue{T}"/>.
+    /// </summary>
+    /// <param name="capacity">Initial capacity of this queue.</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
     public UnsafeQueue(int capacity)
     {
         if (capacity <= 0)


### PR DESCRIPTION
Added some more tests to the project just for fun.

While doing so discovered two bugs in `UnsafeList.Insert`:
 - Capacity did not grow correctly.
 - Copy of data used the wrong count.
   - While debugging this I rewrote the `Insert` copying code to use spans (the extra range checking safety helped track down the issue). I've left that in place but commented out, since I assumed you'd rather stick with `UnsafeArray.Copy`.

Another bug in `UnsafeList.CopyTo`:
 - Array index parameter was not checked, so it was easy to read out of the valid range.
   - Added some checks and throws which should prevent all out-of-bounds access.

Discovered one bug in UnsafeQueue:
 - `TrimExcess()` never actually reduced the capacity
   - Fixed this by modifying `EnsureCapacity` to allow shrinking (with a flag).

One other very small behaviour change (arguable if this is a bug or not):
 - Previously when `Resources.Dipose()` was called then the `Count` would be left unchanged. Now it is set to zero when `Dispose()` is called.