### PR TITLE
Fixed UnsafeList tests in release mode

### DIFF
--- a/Arch.LowLevel.Tests/UnsafeListTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeListTest.cs
@@ -50,8 +50,10 @@ public class UnsafeListTest
         item0 = 11;
         That(list[0], Is.EqualTo(11));
 
+#if DEBUG
         Throws<IndexOutOfRangeException>(() => { var x = list[-1]; });
         Throws<IndexOutOfRangeException>(() => { var x = list[2]; });
+#endif
     }
 
     /// <summary>
@@ -69,8 +71,10 @@ public class UnsafeListTest
         list[0] = 11;
         That(list[0], Is.EqualTo(11));
 
+#if DEBUG
         Throws<IndexOutOfRangeException>(() => { var x = list[-1]; });
         Throws<IndexOutOfRangeException>(() => { var x = list[2]; });
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
Added conditional blocks into the UnsafeList indexer tests to account for expected different behaviour in DEBUG and RELEASE mode.

There's another failure in the `RelationshipCleanup` test which only happens in DEBUG mode. I don't understand that system well enough yet to investigate it.