### PR TITLE
UnsafeArray Tests

### DIFF
--- a/Arch.LowLevel.Tests/UnsafeArrayTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeArrayTest.cs
@@ -1,4 +1,6 @@
-﻿namespace Arch.LowLevel.Tests;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Arch.LowLevel.Tests;
 using static Assert;
 
 /// <summary>
@@ -19,6 +21,19 @@ public class UnsafeArrayTest
         array[2] = 3;
         
         That(array.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void UnsafeArrayEnumerator()
+    {
+        using var array = new UnsafeArray<int>(3);
+        array[0] = 1;
+        array[1] = 2;
+        array[2] = 3;
+
+        var count = 1;
+        foreach (var item in array)
+            That(item, Is.EqualTo(count++));
     }
 
     [Test]
@@ -98,5 +113,25 @@ public class UnsafeArrayTest
             That(resized[i], Is.EqualTo(i));
 
         resized.Dispose();
+    }
+
+    [Test]
+    public void UnsafeArrayEquals()
+    {
+        using var a = new UnsafeArray<int>(8);
+        var b = a;
+
+        That(a, Is.EqualTo(b));
+        That(a == b, Is.True);
+    }
+
+    [Test]
+    public void UnsafeArrayNotEquals()
+    {
+        using var a = new UnsafeArray<int>(8);
+        using var b = new UnsafeArray<int>(8);
+
+        That(a, Is.Not.EqualTo(b));
+        That(a != b, Is.True);
     }
 }

--- a/Arch.LowLevel.Tests/UnsafeArrayTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeArrayTest.cs
@@ -1,5 +1,5 @@
 ﻿namespace Arch.LowLevel.Tests;
-using static NUnit.Framework.Assert;
+using static Assert;
 
 /// <summary>
 ///     Checks <see cref="UnsafeArray{T}"/> related methods.
@@ -19,5 +19,84 @@ public class UnsafeArrayTest
         array[2] = 3;
         
         That(array.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void UnsafeArrayEmptyIsEmpty()
+    {
+        var empty = UnsafeArray.Empty<long>();
+
+        That(empty, Is.Empty);
+
+        empty.Dispose();
+
+        That(empty, Is.Empty);
+    }
+
+    [Test]
+    public void UnsafeArrayFill()
+    {
+        var array = new UnsafeArray<int>(35);
+        using (array)
+        {
+            UnsafeArray.Fill(ref array, 8);
+
+            for (var i = 0; i < array.Length; i++)
+                That(array[i], Is.EqualTo(8));
+        }
+    }
+
+    [Test]
+    public void UnsafeArrayCopy()
+    {
+        var src = new UnsafeArray<int>(15);
+        var dst = new UnsafeArray<int>(6);
+        using (src)
+        using (dst)
+        {
+            for (var i = 0; i < src.Length; i++)
+                src[i] = i;
+
+            UnsafeArray.Fill(ref dst);
+            UnsafeArray.Copy(ref src, 4, ref dst, 1, 4);
+
+            Multiple(() =>
+            {
+                That(dst[0], Is.EqualTo(0));
+                That(dst[1], Is.EqualTo(4));
+                That(dst[2], Is.EqualTo(5));
+                That(dst[3], Is.EqualTo(6));
+                That(dst[4], Is.EqualTo(7));
+                That(dst[5], Is.EqualTo(0));
+            });
+        }
+    }
+
+    [Test]
+    public void UnsafeArrayResizeShrink()
+    {
+        var array = new UnsafeArray<int>(19);
+        for (var i = 0; i < array.Length; i++)
+            array[i] = i;
+
+        var resized = UnsafeArray.Resize(ref array, 8);
+        for (var i = 0; i < resized.Length; i++)
+            That(resized[i], Is.EqualTo(i));
+
+        resized.Dispose();
+    }
+
+    [Test]
+    public void UnsafeArrayResizeGrow()
+    {
+        var array = new UnsafeArray<int>(8);
+        for (var i = 0; i < array.Length; i++)
+            array[i] = i;
+
+        var resized = UnsafeArray.Resize(ref array, 19);
+        for (var i = 0; i < array.Length; i++)
+            That(resized[i], Is.EqualTo(i));
+
+        resized.Dispose();
     }
 }

--- a/Arch.LowLevel/UnsafeArray.cs
+++ b/Arch.LowLevel/UnsafeArray.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -54,7 +53,7 @@ public readonly unsafe struct UnsafeArray<T> : IDisposable where T : unmanaged
     /// <summary>
     ///     The count of this <see cref="UnsafeArray{T}"/> instance, its capacity.
     /// </summary>
-    public readonly int Count
+    public int Count
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get;
@@ -63,7 +62,7 @@ public readonly unsafe struct UnsafeArray<T> : IDisposable where T : unmanaged
     /// <summary>
     ///     The count of this <see cref="UnsafeArray{T}"/> instance, its capacity.
     /// </summary>
-    public readonly int Length
+    public int Length
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => Count;
@@ -228,7 +227,6 @@ public unsafe struct UnsafeArray
     /// <param name="destinationIndex">The start index in the destination <see cref="UnsafeArray{T}"/>.</param>
     /// <param name="length">The length indicating the amount of items being copied.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Pure]
     public static void Copy<T>(ref UnsafeArray<T> source, int index, ref UnsafeArray<T> destination, int destinationIndex, int length) where T : unmanaged
     {
         var size = sizeof(T);
@@ -245,13 +243,9 @@ public unsafe struct UnsafeArray
     /// <param name="source">The <see cref="UnsafeArray{T}"/> instance.</param>
     /// <param name="value">The value.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Pure]
     public static void Fill<T>(ref UnsafeArray<T> source, in T value = default) where T : unmanaged
     {
-        for (var index = 0; index < source.Count; index++)
-        {
-            source[index] = value;
-        }
+        source.AsSpan().Fill(value);
     }
     
     /// <summary>
@@ -265,7 +259,7 @@ public unsafe struct UnsafeArray
     public static UnsafeArray<T> Resize<T>(ref UnsafeArray<T> source, int newCapacity) where T : unmanaged
     {
         var destination = new UnsafeArray<T>(newCapacity);
-        Copy(ref source, 0, ref destination, 0, source.Length);
+        Copy(ref source, 0, ref destination, 0, Math.Min(source.Length, destination.Length));
 
         source.Dispose();
         return destination;


### PR DESCRIPTION
Improved Test coverage for `UnsafeArray` and fixed some issues:
 - Removed some `[Pure]` attributes (meaningless on `void` method)
 - Removed some `readonly` modifiers on methods (meaningless on methods inside a `readonly` struct)
 - Replaced `Fill` implementation with `Span.Fill` (which is simpler and should be faster)
 - Fixed resize (previously it could only ever grow, never shrink)
