### PR TITLE
System Timing Metrics

### DIFF
--- a/Arch.Extended.Sample/Game.cs
+++ b/Arch.Extended.Sample/Game.cs
@@ -85,6 +85,7 @@ public class Game : Microsoft.Xna.Framework.Game
         
         // Create systems, running in order
         _systems = new Group<GameTime>(
+            "Systems",
             new MovementSystem(_world, GraphicsDevice.Viewport.Bounds),
             new ColorSystem(_world),
             new DebugSystem(_world)


### PR DESCRIPTION
Added automatic collection of timing metrics to the system group.

This will automatically publish metrics about elapsed time for `BeforeUpdate`, `Update` and `AfterUpdate` for every system in a group.

This can be used with the `dotnet-counters` tool like this:
> dotnet-counters monitor --name ProcessName --counters "Some.Counter.Name"

To get results like this:

```powershell
Press p to pause, r to resume, q to quit.
    Status: Running

[Some.Counter.Name]
    Update.ElapsedMilliseconds (millisecond)
        Percentile=50                                                      0.037
        Percentile=95                                                      0.057
        Percentile=99                                                      0.065
```

### Breaking Change

Note that as this is currently written it is a **breaking change** to `Group<T>` since the constructor now requires a name (which is used to name the metric). I think it makes sense to have a name on the Group anyway (very helpful when debugging or writing tools to inspect the scene for example).

If you'd rather avoid a breaking change here I could add two new constructors with the old signature which use a default name (e.g. `Arch.SystemGroup`). That way passing in a name becomes optional.