### PR TITLE
Fixing ContainsKey

### DIFF
--- a/Arch.LowLevel/Jagged/SparseJaggedArray.cs
+++ b/Arch.LowLevel/Jagged/SparseJaggedArray.cs
@@ -308,7 +308,7 @@ public class SparseJaggedArray<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ContainsKey(int index)
     {
-        if (index <= 0 || index > Capacity)
+        if (index <= 0 || index >= Capacity)
         {
             return false;
         }


### PR DESCRIPTION
Found a bug when adding a component and its Index is the size of the SparseJaggedArray, was throwing a System.IndexOutOfRangeException
