### PR TITLE
`[ParallelQuery]` Attribute

### DIFF
--- a/Arch.System.SourceGenerator/Extensions/GeneratorSyntaxContextExtensions.cs
+++ b/Arch.System.SourceGenerator/Extensions/GeneratorSyntaxContextExtensions.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Arch.System.SourceGenerator.Extensions;
+
+internal static class GeneratorSyntaxContextExtensions
+{
+    /// <summary>
+    ///     Returns a <see cref="MethodDeclarationSyntax"/> if its annocated with a attribute of <see cref="name"/>.
+    /// </summary>
+    /// <param name="context">Its <see cref="GeneratorSyntaxContext"/>.</param>
+    /// <param name="name">The attributes name.</param>
+    /// <returns></returns>
+    public static MethodDeclarationSyntax? GetMethodSymbolIfAttributeOf(ref this GeneratorSyntaxContext context, string name)
+    {
+        // we know the node is a EnumDeclarationSyntax thanks to IsSyntaxTargetForGeneration
+        var enumDeclarationSyntax = (MethodDeclarationSyntax)context.Node;
+
+        // loop through all the attributes on the method
+        foreach (var attributeListSyntax in enumDeclarationSyntax.AttributeLists)
+        {
+            foreach (var attributeSyntax in attributeListSyntax.Attributes)
+            {
+                if (context.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol is not IMethodSymbol attributeSymbol)
+                    continue;
+
+                var attributeContainingTypeSymbol = attributeSymbol.ContainingType;
+                var fullName = attributeContainingTypeSymbol.ToDisplayString();
+
+                // Is the attribute the [EnumExtensions] attribute?
+                if (fullName != name)
+                    continue;
+
+                return enumDeclarationSyntax;
+            }
+        }
+
+        // we didn't find the attribute we were looking for
+        return null;
+    }
+}

--- a/Arch.System.SourceGenerator/Extensions/IMethodSymbolExtensions.cs
+++ b/Arch.System.SourceGenerator/Extensions/IMethodSymbolExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 
-namespace Arch.System.SourceGenerator;
+namespace Arch.System.SourceGenerator.Extensions;
 
 public static class IMethodSymbolExtensions
 {
@@ -11,7 +11,7 @@ public static class IMethodSymbolExtensions
     /// <param name="ms">The <see cref="IMethodSymbol"/> instance.</param>
     /// <param name="name">The attributes name.</param>
     /// <returns>The attribute wrapped in an <see cref="AttributeData"/>.</returns>
-    public static AttributeData GetAttributeData(this IMethodSymbol ms, string name)
+    public static AttributeData? GetAttributeData(this IMethodSymbol ms, string name)
     {
         foreach (var attribute in ms.GetAttributes())
         {

--- a/Arch.System.SourceGenerator/Model.cs
+++ b/Arch.System.SourceGenerator/Model.cs
@@ -47,7 +47,12 @@ public struct QueryMethod
     /// The namespace of the method.
     /// </summary>
     public string Namespace { get; set; }
-    
+
+    /// <summary>
+    /// If this method is marked with a [ParallelQuery] attribute
+    /// </summary>
+    public bool IsParallelQuery { get; set; }
+
     /// <summary>
     /// If this method is static.
     /// </summary>

--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Immutable;
-using System.Text;
+﻿using System.Text;
+using Arch.System.SourceGenerator.Extensions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Emit;
 
 namespace Arch.System.SourceGenerator;
 
@@ -155,6 +153,8 @@ public static class QueryUtils
     /// <returns></returns>
     public static StringBuilder AppendQueryMethod(this StringBuilder sb, IMethodSymbol methodSymbol)
     {
+        // Determine which type of query to generate
+        var parallel = methodSymbol.GetAttributeData("Arch.System.ParallelQueryAttribute") != null;
 
         // Check for entity param
         var entity = methodSymbol.Parameters.Any(symbol => symbol.Type.Name.Equals("Entity"));
@@ -194,7 +194,7 @@ public static class QueryUtils
         noneArray.RemoveAll(symbol => symbol.Name.Equals("Entity"));
         exclusiveArray.RemoveAll(symbol => symbol.Name.Equals("Entity"));
 
-        // Create data modell and generate it
+        // Create data model and generate it
         var className = methodSymbol.ContainingSymbol.ToString();
         var queryMethod = new QueryMethod
         {
@@ -202,6 +202,7 @@ public static class QueryUtils
             Namespace = methodSymbol.ContainingNamespace.ToString(),
             ClassName = className.Substring(className.LastIndexOf('.')+1),
             
+            IsParallelQuery = parallel,
             IsStatic = methodSymbol.IsStatic,
             IsEntityQuery = entity,
             MethodName = methodSymbol.Name,

--- a/Arch.System/Attributes.cs
+++ b/Arch.System/Attributes.cs
@@ -8,6 +8,15 @@ public class QueryAttribute : global::System.Attribute
 {
 }
 
+/// <summary>
+///     Marks a method to generate a high performance parallelised query for it. 
+/// </summary>
+[global::System.AttributeUsage(global::System.AttributeTargets.Method)]
+public class ParallelQueryAttribute
+    : global::System.Attribute
+{
+}
+
 
 /// <summary>
 ///     Marks a parameter as "data". This will be taken into account during source generation and will still be passed as a parameter in the query method.


### PR DESCRIPTION
Initial work on adding a `ParallelQuery` attribute, as mentioned in https://github.com/genaray/Arch/issues/66.

So far this does all the necessary work to fork into two different generator paths (for parallel and serial) but then generates the **same thing** in both paths!

I'm opening this draft PR to get some discussion started on what the parallel version should look like?
 - Copy the contents of `World.ParallelQuery`?
 - Just a make call to `World.ParallelQuery`/`World.InlineParallelQuery`?
 - Something else entirely entirely?