### PR TITLE
UnsafeStack Tests

### DIFF
--- a/Arch.LowLevel.Tests/UnsafeStackTest.cs
+++ b/Arch.LowLevel.Tests/UnsafeStackTest.cs
@@ -9,22 +9,171 @@ using static NUnit.Framework.Assert;
 [TestFixture]
 public class UnsafeStackTest
 {
-   
     /// <summary>
-    ///     Checks if <see cref="UnsafeStack{T}"/> is capable of adding itemss.
+    ///     Checks if <see cref="UnsafeStack{T}"/> checks for invalid capacity on construction.
+    /// </summary>
+    [Test]
+    public void UnsafeStackInvalidCapacity()
+    {
+        Throws<ArgumentOutOfRangeException>(() => new UnsafeStack<int>(-9));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}"/> is capable of adding items.
     /// </summary>
     [Test]
     public void UnsafeStackAdd()
     {
         using var stack = new UnsafeStack<int>(8);
+
+        That(stack.IsFull, Is.False);
+        That(stack.IsEmpty, Is.True);
+
         stack.Push(1);
         stack.Push(2);
         stack.Push(3);
-        
+
+        That(stack.IsFull, Is.False);
+        That(stack.IsEmpty, Is.False);
+
         That(stack.Count, Is.EqualTo(3));
         That(stack.Peek(), Is.EqualTo(3));
     }
-    
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}"/> is can be converted to a span
+    /// </summary>
+    [Test]
+    public void UnsafeStackAsSpan()
+    {
+        using var stack = new UnsafeStack<int>(8);
+
+        stack.Push(1);
+        stack.Push(2);
+        stack.Push(3);
+
+        var span = stack.AsSpan();
+
+        stack.Pop();
+        stack.Push(4);
+
+        That(span.Length, Is.EqualTo(3));
+
+        CollectionAssert.AreEqual(span.ToArray(), new[] { 1, 2, 4 });
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}"/> is capable of adding items even past the initial capacity
+    /// </summary>
+    [Test]
+    public void UnsafeStackAddBeyondCapacity()
+    {
+        using var stack = new UnsafeStack<int>(4);
+        That(stack.Capacity, Is.EqualTo(4));
+
+        stack.Push(1);
+        stack.Push(2);
+        stack.Push(3);
+        stack.Push(4);
+        That(stack.IsFull, Is.True);
+        stack.Push(5);
+        stack.Push(6);
+        stack.Push(7);
+
+        That(stack.Count, Is.EqualTo(7));
+        That(stack.Peek(), Is.EqualTo(7));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}.EnsureCapacity"/> expands capacity
+    /// </summary>
+    [Test]
+    public void UnsafeStackEnsureCapacityExpands()
+    {
+        using var stack = new UnsafeStack<int>(10);
+        That(stack.Capacity, Is.EqualTo(10));
+
+        stack.EnsureCapacity(11);
+
+        That(stack.Capacity, Is.GreaterThanOrEqualTo(11));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}.EnsureCapacity"/> cannot shrink the capacity
+    /// </summary>
+    [Test]
+    public void UnsafeStackEnsureCapacityCannotShrink()
+    {
+        using var stack = new UnsafeStack<int>(10);
+        That(stack.Capacity, Is.EqualTo(10));
+
+        stack.EnsureCapacity(1);
+
+        That(stack.Capacity, Is.EqualTo(10));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}.EnsureCapacity"/> can add a massive amount of new capacity
+    /// </summary>
+    [Test]
+    public void UnsafeStackEnsureCapacityExpandsALot()
+    {
+        using var stack = new UnsafeStack<int>(10);
+        That(stack.Capacity, Is.EqualTo(10));
+
+        stack.EnsureCapacity(10000);
+
+        That(stack.Capacity, Is.GreaterThanOrEqualTo(10000));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}.TrimExcess"/> can remove unused capacity
+    /// </summary>
+    [Test]
+    public void UnsafeStackTrimExcessShrinks()
+    {
+        using var stack = new UnsafeStack<int>(10);
+        That(stack.Capacity, Is.EqualTo(10));
+
+        stack.TrimExcess();
+
+        That(stack.Capacity, Is.LessThan(10));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}.TrimExcess"/> does not expand
+    /// </summary>
+    [Test]
+    public void UnsafeStackTrimExcessNeverExpands()
+    {
+        using var stack = new UnsafeStack<int>(2);
+        
+        stack.TrimExcess();
+
+        That(stack.Capacity, Is.LessThanOrEqualTo(2));
+    }
+
+    /// <summary>
+    ///     Checks if <see cref="UnsafeStack{T}"/> is capable of being cleared.
+    /// </summary>
+    [Test]
+    public void UnsafeStackClear()
+    {
+        using var stack = new UnsafeStack<int>(8);
+        stack.Push(1);
+        stack.Push(2);
+        stack.Push(3);
+
+        That(stack.Count, Is.EqualTo(3));
+        That(stack.Peek(), Is.EqualTo(3));
+
+        stack.Clear();
+
+        That(stack.Count, Is.EqualTo(0));
+        Throws<InvalidOperationException>(() => stack.Peek());
+        Throws<InvalidOperationException>(() => stack.Pop());
+    }
+
     /// <summary>
     ///     Checks if <see cref="UnsafeStack{T}"/> is capable of peeking itemss.
     /// </summary>

--- a/Arch.LowLevel/UnsafeStack.cs
+++ b/Arch.LowLevel/UnsafeStack.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Arch.LowLevel;
@@ -51,7 +49,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// <summary>
     ///     The amount of items in the stack.
     /// </summary>
-    public int Count
+    public readonly int Count
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => _count;
@@ -60,7 +58,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// <summary>
     ///     The total capacity of this stack.
     /// </summary>
-    public int Capacity
+    public readonly int Capacity
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => _capacity;
@@ -69,7 +67,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// <summary>
     ///     If this stack is empty.
     /// </summary>
-    public bool IsEmpty
+    public readonly bool IsEmpty
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => _count == 0;
@@ -78,7 +76,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// <summary>
     ///     If this stack is full. 
     /// </summary>
-    public bool IsFull
+    public readonly bool IsFull
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => _count >= _capacity;
@@ -204,9 +202,8 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     ///     Converts this <see cref="UnsafeStack{T}"/> instance into a <see cref="Span{T}"/>.
     /// </summary>
     /// <returns>A new instance of <see cref="Span{T}"/>.</returns>
-    [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Span<T> AsSpan()
+    public readonly Span<T> AsSpan()
     {
         return new Span<T>(_stack, Count);
     }
@@ -216,7 +213,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// </summary>
     /// <returns>A new <see cref="UnsafeEnumerator{T}"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public UnsafeReverseEnumerator<T> GetEnumerator()
+    public readonly UnsafeReverseEnumerator<T> GetEnumerator()
     {
         return new UnsafeReverseEnumerator<T>(_stack, Count);
     }
@@ -226,7 +223,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// </summary>
     /// <returns>The new <see cref="IEnumerable{T}"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    readonly IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
         return new ReverseEnumerator<T>(_stack, Count);
     }
@@ -236,7 +233,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// </summary>
     /// <returns>The new <see cref="IEnumerator"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    IEnumerator IEnumerable.GetEnumerator()
+    readonly IEnumerator IEnumerable.GetEnumerator()
     {
         return new ReverseEnumerator<T>(_stack, Count);
     }
@@ -246,7 +243,7 @@ public unsafe struct UnsafeStack<T> :  IEnumerable<T>, IDisposable where T : unm
     /// </summary>
     /// <returns>The string.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString()
+    public readonly override string ToString()
     {
         var items = new StringBuilder();
         foreach (ref var item in this)


### PR DESCRIPTION
 - Added some more tests to the UnsafeStack, covering everything but `ToString`.
   - No issues found.
 - Added `readonly` to a load of methods in `UnsafeStack` which can benefit from them (replacing `[Pure]` annotation where necessary).