### PR TITLE
Partial Fix For Source Generated Queries

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -260,15 +260,15 @@ public static class QueryUtils
                         Exclusive = {{exclusiveTypeArray}}
                     };
 
-                    private {{staticModifier}} bool _{{queryMethod.MethodName}}_Initialized;
+                    private {{staticModifier}} World? _{{queryMethod.MethodName}}_Initialized;
                     private {{staticModifier}} Query _{{queryMethod.MethodName}}_Query;
 
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     public {{staticModifier}} void {{queryMethod.MethodName}}Query(World world {{data}}){
                      
-                        if(!_{{queryMethod.MethodName}}_Initialized){
+                        if(!ReferenceEquals(_{{queryMethod.MethodName}}_Initialized, world)) {
                             _{{queryMethod.MethodName}}_Query = world.Query(in {{queryMethod.MethodName}}_QueryDescription);
-                            _{{queryMethod.MethodName}}_Initialized = true;
+                            _{{queryMethod.MethodName}}_Initialized = world;
                         }
 
                         foreach(ref var chunk in _{{queryMethod.MethodName}}_Query.GetChunkIterator()){


### PR DESCRIPTION
Source generated queries are unusable if multiple worlds are being used. This is because the cached `Query` object will be used with the wrong `World`, leading to bad query results. See #54 

This fixes that by storing which world the cache is relevant for.

**This is only a partial fix**. If multiple worlds are being used with multithreading then the cache may be made invalid by another thread while it's in use.