### PR TITLE
Rider and CSharp proj tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ riderModule.iml
 
 # Rider
 # Rider auto-generates .iml files, and contentModel.xml
+.idea
 **/.idea/**/*.iml
 **/.idea/**/contentModel.xml
 **/.idea/**/modules.xml
@@ -43,3 +44,4 @@ Footer
 © 2022 GitHub, Inc.
 Footer navigation
 Terms
+

--- a/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
+++ b/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        
+
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
@@ -29,6 +29,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Copyright>Apache2.0</Copyright>
         <PackageLicenseUrl></PackageLicenseUrl>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Arch.EventBus/Arch.EventBus.csproj
+++ b/Arch.EventBus/Arch.EventBus.csproj
@@ -30,6 +30,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Copyright>Apache2.0</Copyright>
         <PackageLicenseUrl></PackageLicenseUrl>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Arch.Extended.sln.DotSettings
+++ b/Arch.Extended.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/CustomBuildToolPath/@EntryValue">/usr/local/share/dotnet/sdk/8.0.101/MSBuild.dll</s:String>
+	<s:Int64 x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MsbuildVersion/@EntryValue">4294967293</s:Int64></wpf:ResourceDictionary>

--- a/Arch.LowLevel/Arch.LowLevel.csproj
+++ b/Arch.LowLevel/Arch.LowLevel.csproj
@@ -29,6 +29,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Copyright>Apache2.0</Copyright>
         <PackageLicenseUrl></PackageLicenseUrl>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
 
         <UnityPublish>true</UnityPublish>
     </PropertyGroup>

--- a/Arch.Persistence/Arch.Persistence.csproj
+++ b/Arch.Persistence/Arch.Persistence.csproj
@@ -20,6 +20,7 @@
         <PackageTags>c#;.net;.net6;.net7;ecs;game;entity;gamedev; game-development; game-engine; entity-component-system; arch;</PackageTags>
         <PackageReleaseNotes>Updated to Arch 1.2.7</PackageReleaseNotes>
         <Version>1.0.3</Version>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
 
         <UnityPublish>true</UnityPublish>
     </PropertyGroup>

--- a/Arch.Relationships/Arch.Relationships.csproj
+++ b/Arch.Relationships/Arch.Relationships.csproj
@@ -10,7 +10,7 @@
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        
+
         <Title>Arch.Relationships</Title>
         <Description>Simple Entity-Relationships for Arch.</Description>
         <Copyright>Apache2.0</Copyright>
@@ -21,6 +21,7 @@
         <PackageReleaseNotes>Relationships now use less memory and are serializable.</PackageReleaseNotes>
         <Authors>genaray</Authors>
         <Version>1.0.1</Version>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
 
         <UnityPublish>true</UnityPublish>
     </PropertyGroup>

--- a/Arch.System.SourceGenerator/Arch.System.SourceGenerator.csproj
+++ b/Arch.System.SourceGenerator/Arch.System.SourceGenerator.csproj
@@ -19,7 +19,7 @@
         <Description>A source generator for arch.system.</Description>
         <PackageReleaseNotes>Data is now passed correctly into generated queries.
 `@` in fromt of params is now accepted.
-Added `World _world` to generated queries for making them usable in different worlds. 
+Added `World _world` to generated queries for making them usable in different worlds.
 </PackageReleaseNotes>
         <PackageTags>c#;.net;.net6;.net7;ecs;game;entity;gamedev; game-development; game-engine; entity-component-system; arch;</PackageTags>
 
@@ -32,6 +32,7 @@ Added `World _world` to generated queries for making them usable in different wo
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Copyright>Apache2.0</Copyright>
         <PackageLicenseUrl></PackageLicenseUrl>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Arch.System/Arch.System.csproj
+++ b/Arch.System/Arch.System.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net7.0; net6.0; netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
-        
+
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
@@ -29,6 +29,7 @@ Some other small improvements.</PackageReleaseNotes>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Copyright>Apache2.0</Copyright>
         <PackageLicenseUrl></PackageLicenseUrl>
+        <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
 
         <UnityPublish>true</UnityPublish>
     </PropertyGroup>


### PR DESCRIPTION
I have a few PR's I'd like to, this being the first one.

This PR includes:
* A few auto-generated files and `.gitignore` from Rider when opening the Arch.Extended solution.
* When originally opening the solution in Rider all projects appeared to be failing to compile. This was due to the default **MsBuildVersion** being lower than what is needed to successfully compile. I've modified the Rider setting to use the auto-detected **MsBuildVersion** to resolve this.
* I've modified the runtime CSharp projects to include the `SatelliteResourceLanguages` XML tag to limit languages to English for Humanizer. When publishing these projects this prevents many [extraneous assemblies](https://stackoverflow.com/questions/30262592/omit-localized-versions-of-assemblies-from-the-build-output) from being included with the build output.

The result of these changes is that Rider can now successfully compile the solution and publishing these assemblies includes far-less file content.

 
![image](https://github.com/genaray/Arch.Extended/assets/1663648/8bb4eb1d-c21d-4f86-9a60-659dd3936bef)