### PR TITLE
Unity compatibility adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ Footer
 © 2022 GitHub, Inc.
 Footer navigation
 Terms
-
+/UnityPublish

--- a/.run/Publish Arch.AOT.SourceGenerator to Unity Publish.run.xml
+++ b/.run/Publish Arch.AOT.SourceGenerator to Unity Publish.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Arch.AOT.SourceGenerator to Unity Publish" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/UnityPublish/SourceGenerators" target_framework="netstandard2.0" uuid_high="720741342265887674" uuid_low="-5713872599858624605" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Publish Arch.EventBus to Unity Publish.run.xml
+++ b/.run/Publish Arch.EventBus to Unity Publish.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Arch.EventBus to Unity Publish" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/UnityPublish/SourceGenerators" target_framework="netstandard2.0" uuid_high="-8378326082408201200" uuid_low="-8691373370981991138" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Publish Arch.LowLevel to Unity Publish.run.xml
+++ b/.run/Publish Arch.LowLevel to Unity Publish.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Arch.LowLevel to Unity Publish" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/UnityPublish/Plugins" target_framework="netstandard2.1" uuid_high="50739187434734475" uuid_low="-7009414175307955308" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Publish Arch.Persistence to Unity Publish.run.xml
+++ b/.run/Publish Arch.Persistence to Unity Publish.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Arch.Persistence to Unity Publish" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/UnityPublish/Plugins" target_framework="netstandard2.1" uuid_high="5662267713841744598" uuid_low="-8394478303791080086" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Publish Arch.Relationships to Unity Publish.run.xml
+++ b/.run/Publish Arch.Relationships to Unity Publish.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Arch.Relationships to Unity Publish" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/UnityPublish/Plugins" target_framework="netstandard2.1" uuid_high="5995509060479107102" uuid_low="-5315975434817346068" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Publish Arch.System to Unity Publish.run.xml
+++ b/.run/Publish Arch.System to Unity Publish.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Arch.System to Unity Publish" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/UnityPublish/Plugins" target_framework="netstandard2.1" uuid_high="4122545287363773375" uuid_low="-9004959171293611199" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Publish Arch.System.SourceGenerator to UnityPublish.run.xml
+++ b/.run/Publish Arch.System.SourceGenerator to UnityPublish.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Arch.System.SourceGenerator to UnityPublish" type="DotNetFolderPublish" factoryName="Publish to folder">
+    <riderPublish configuration="Release" platform="Any CPU" runtime="Portable" target_folder="$PROJECT_DIR$/UnityPublish/SourceGenerators" target_framework="netstandard2.0" uuid_high="-3748783982788918185" uuid_low="-8107627493768795406" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -38,7 +38,7 @@ public static class StringBuilderExtensions
 		    	internal static class GeneratedComponentRegistry
 		    	{
 		    		#if UNITY_5_6_OR_NEWER
-		    		[RuntimeInitializeOnLoadMethod]
+		    		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
 		    		#else
 		    		[ModuleInitializer]
 		    		#endif

--- a/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -16,29 +16,37 @@ public static class StringBuilderExtensions
 	/// <returns></returns>
 	public static StringBuilder AppendComponentTypes(this StringBuilder sb, IList<ComponentType> componentTypes)
 	{
-		// Lists the component registration commands line by line. 
+		// Lists the component registration commands line by line.
 		var components = new StringBuilder();
 		foreach (var type in componentTypes)
 		{
 			var componentType = type;
 			components.AppendComponentType(ref componentType);
 		}
-		
+
 		sb.AppendLine(
 			$$"""
 		    using System.Runtime.CompilerServices;
 		    using Arch.Core.Utils;
-		              
+		    
+		    #if UNITY_5_6_OR_NEWER
+		    using UnityEngine;
+		    #endif
+		    
 		    namespace Arch.AOT.SourceGenerator
 		    {
-		       internal static class GeneratedComponentRegistry
-		       {
-		          [ModuleInitializer]
-		          public static void Initialize()
-		          {
-		          {{components}}
-		          }
-		       }
+		    	internal static class GeneratedComponentRegistry
+		    	{
+		    		#if UNITY_5_6_OR_NEWER
+		    		[RuntimeInitializeOnLoadMethod]
+		    		#else
+		    		[ModuleInitializer]
+		    		#endif
+		    		public static void Initialize()
+		    		{
+		    		{{components}}
+		    		}
+		    	}
 		    }
 		    """
 		);
@@ -55,7 +63,7 @@ public static class StringBuilderExtensions
 	{
 		//var size = componentType.IsValueType ? $"Unsafe.SizeOf<{componentType.TypeName}>()" : "IntPtr.Size";
 		//sb.AppendLine($"ComponentRegistry.Add(typeof({componentType.TypeName}), new ComponentType(ComponentRegistry.Size + 1, {size}));");
-		
+
 		sb.AppendLine($"ArrayRegistry.Add<{componentType.TypeName}>();");
 		return sb;
 	}

--- a/Arch.AOT.SourceGenerator/SourceGenerator.cs
+++ b/Arch.AOT.SourceGenerator/SourceGenerator.cs
@@ -15,12 +15,12 @@ namespace Arch.AOT.SourceGenerator;
 public sealed class ComponentRegistryGenerator : IIncrementalGenerator
 {
 	/// <summary>
-	///		A <see cref="List{T}"/> of annotated components (their types) found via the source-gen. 
+	///		A <see cref="List{T}"/> of annotated components (their types) found via the source-gen.
 	/// </summary>
 	private readonly List<ComponentType> _componentTypes = new();
-	
+
 	/// <summary>
-	///		The attribute to mark components with in order to be found by this source-gen. 
+	///		The attribute to mark components with in order to be found by this source-gen.
 	/// </summary>
 	private const string AttributeTemplate = """
 	                                         using System;
@@ -124,7 +124,7 @@ public sealed class ComponentRegistryGenerator : IIncrementalGenerator
 			foreach (var member in typeSymbol.GetMembers())
 			{
 				if (member is not IFieldSymbol) continue;
-				
+
 				hasZeroFields = false;
 				break;
 			}
@@ -132,6 +132,9 @@ public sealed class ComponentRegistryGenerator : IIncrementalGenerator
 			var typeName = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 			_componentTypes.Add(new ComponentType(typeName, hasZeroFields, typeSymbol.IsValueType));
 		}
+
+		// Order component types by type name (a-z)
+		_componentTypes.Sort((x, y) => x.TypeName.CompareTo(y.TypeName));
 
 		sb.AppendComponentTypes(_componentTypes);
 		productionContext.AddSource("GeneratedComponentRegistry.g.cs",CSharpSyntaxTree.ParseText(sb.ToString()).GetRoot().NormalizeWhitespace().ToFullString());

--- a/Arch.Extended.Sample/Arch.Extended.Sample.csproj
+++ b/Arch.Extended.Sample/Arch.Extended.Sample.csproj
@@ -2,11 +2,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Arch.Extended</RootNamespace>
-        <LangVersion>12</LangVersion>
+        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Arch.Extended.Sample/Game.cs
+++ b/Arch.Extended.Sample/Game.cs
@@ -6,9 +6,9 @@ using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.Bus;
 using Arch.Core.Extensions.Dangerous;
-using Arch.Core.Utils;
 using Arch.Persistence;
 using Arch.Relationships;
+using Arch.System;
 using MessagePack;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -45,7 +45,7 @@ public class Game : Microsoft.Xna.Framework.Game
         _graphics = new GraphicsDeviceManager(this);
         Content.RootDirectory = "Content";
     }
-    
+
     protected override void Initialize()
     {
         // Setup texture and randomness
@@ -54,17 +54,17 @@ public class Game : Microsoft.Xna.Framework.Game
 
         base.Initialize();
     }
-    
+
     protected override void LoadContent()
     {
         // Create a new SpriteBatch, which can be used to draw textures.
         _spriteBatch = new SpriteBatch(GraphicsDevice);
     }
-    
+
     protected override void BeginRun()
     {
         base.BeginRun();
-        
+
         // Create world & JobScheduler for multithreading
         _world = World.Create();
         _jobScheduler = new(
@@ -82,8 +82,8 @@ public class Game : Microsoft.Xna.Framework.Game
         for (var index = 0; index < 10; index++)
         {
             _world.Create(
-                new Position{ Vector2 = _random.NextVector2(GraphicsDevice.Viewport.Bounds) }, 
-                new Velocity{ Vector2 = _random.NextVector2(-0.25f,0.25f) }, 
+                new Position{ Vector2 = _random.NextVector2(GraphicsDevice.Viewport.Bounds) },
+                new Velocity{ Vector2 = _random.NextVector2(-0.25f,0.25f) },
                 new Sprite{ Texture2D = _texture2D, Color = _random.NextColor() }
             );
         }
@@ -99,14 +99,14 @@ public class Game : Microsoft.Xna.Framework.Game
         _world = archSerializer.Deserialize(worldJson);
         
         // Create systems, running in order
-        _systems = new System.Group<GameTime>(
+        _systems = new Group<GameTime>(
             "Systems",
             new MovementSystem(_world, GraphicsDevice.Viewport.Bounds),
             new ColorSystem(_world),
             new DebugSystem(_world)
         );
-        _drawSystem = new DrawSystem(_world, _spriteBatch);  // Draw system must be its own system since monogame differentiates between update and draw. 
-        
+        _drawSystem = new DrawSystem(_world, _spriteBatch);  // Draw system must be its own system since monogame differentiates between update and draw.
+
         // Initialize systems
         _systems.Initialize();
         _drawSystem.Initialize();
@@ -116,7 +116,7 @@ public class Game : Microsoft.Xna.Framework.Game
     {
         // Exit game on press
         if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape)) Exit();
-        
+
         // Forward keyboard state as an event to another handles by using the eventbus
         var @event = (_world, Keyboard.GetState());
         EventBus.Send(ref @event);
@@ -193,31 +193,31 @@ public class Game : Microsoft.Xna.Framework.Game
         }
         
         // Update systems
-        _systems.BeforeUpdate(in gameTime);
-        _systems.Update(in gameTime);
-        _systems.AfterUpdate(in gameTime);
+        _systems.BeforeExecute(in gameTime);
+        _systems.Execute(in gameTime);
+        _systems.AfterExecute(in gameTime);
         base.Update(gameTime);
     }
-    
+
     protected override void Draw(GameTime gameTime)
     {
         _graphics.GraphicsDevice.Clear(Color.CornflowerBlue);
-        
+
         // Update draw system and draw stuff
-        _drawSystem.BeforeUpdate(in gameTime);
-        _drawSystem.Update(in gameTime);
-        _drawSystem.AfterUpdate(in gameTime);
+        _drawSystem.BeforeExecute(in gameTime);
+        _drawSystem.Execute(in gameTime);
+        _drawSystem.AfterExecute(in gameTime);
         base.Draw(gameTime);
     }
 
     protected override void EndRun()
     {
         base.EndRun();
-        
-        // Destroy world and shutdown the jobscheduler 
+
+        // Destroy world and shutdown the jobscheduler
         World.Destroy(_world);
         _jobScheduler.Dispose();
-        
+
         // Dispose systems
         _systems.Dispose();
     }

--- a/Arch.Extended.Sample/Systems.cs
+++ b/Arch.Extended.Sample/Systems.cs
@@ -11,17 +11,17 @@ using Microsoft.Xna.Framework.Input;
 namespace Arch.Extended;
 
 /// <summary>
-///     The movement system makes the entities move and bounce properly. 
+///     The movement system makes the entities move and bounce properly.
 /// </summary>
 public partial class MovementSystem : BaseSystem<World, GameTime>
 {
-    
+
     /// <summary>
     ///     A rectangle which specifies the viewport.
     ///     Needed so that the entities do not wander outside the viewport.
     /// </summary>
     private readonly Rectangle _viewport;
-    
+
     /// <summary>
     ///     Creates a <see cref="MovementSystem"/> instance.
     /// </summary>
@@ -42,7 +42,7 @@ public partial class MovementSystem : BaseSystem<World, GameTime>
     {
         pos.Vector2 += time.ElapsedGameTime.Milliseconds * vel.Vector2;
     }
-    
+
     /// <summary>
     ///     Called for each <see cref="Entity"/> to move it.
     ///     The calling takes place through the source generated method "MoveQuery" on <see cref="BaseSystem{W,T}.Update"/>.
@@ -55,20 +55,20 @@ public partial class MovementSystem : BaseSystem<World, GameTime>
     {
         if (pos.Vector2.X >= _viewport.X + _viewport.Width)
             vel.Vector2.X = -vel.Vector2.X;
-            
+
         if (pos.Vector2.Y >= _viewport.Y + _viewport.Height)
             vel.Vector2.Y = -vel.Vector2.Y;
-            
+
         if (pos.Vector2.X <= _viewport.X)
             vel.Vector2.X = -vel.Vector2.X;
-            
+
         if (pos.Vector2.Y <= _viewport.Y)
             vel.Vector2.Y = -vel.Vector2.Y;
     }
 }
 
 /// <summary>
-///     Color system, modifies each entities color slowly. 
+///     Color system, modifies each entities color slowly.
 /// </summary>
 public partial class ColorSystem : BaseSystem<World, GameTime>
 {
@@ -95,7 +95,7 @@ public partial class ColorSystem : BaseSystem<World, GameTime>
 }
 
 /// <summary>
-///     The draw system, handles the drawing of <see cref="Entity"/> sprites at their position. 
+///     The draw system, handles the drawing of <see cref="Entity"/> sprites at their position.
 /// </summary>
 public partial class DrawSystem : BaseSystem<World, GameTime>
 {
@@ -103,7 +103,7 @@ public partial class DrawSystem : BaseSystem<World, GameTime>
     ///     The <see cref="SpriteBatch"/> used for drawing all <see cref="Entity"/>s.
     /// </summary>
     private readonly SpriteBatch _batch;
-    
+
     /// <summary>
     ///     Creates a <see cref="DrawSystem"/> instance.
     /// </summary>
@@ -115,9 +115,9 @@ public partial class DrawSystem : BaseSystem<World, GameTime>
     ///     Is called before the <see cref="BaseSystem{W,T}.Update"/> to start with the <see cref="SpriteBatch"/> recording.
     /// </summary>
     /// <param name="t">The <see cref="GameTime"/>.</param>
-    public override void BeforeUpdate(in GameTime t)
+    public override void BeforeExecute(in GameTime t)
     {
-        base.BeforeUpdate(in t);
+        base.BeforeExecute(in t);
         _batch.Begin();
     }
 
@@ -138,15 +138,15 @@ public partial class DrawSystem : BaseSystem<World, GameTime>
     ///     Is called after the <see cref="BaseSystem{W,T}.Update"/> to stop the <see cref="SpriteBatch"/> recording.
     /// </summary>
     /// <param name="t">The <see cref="GameTime"/>.</param>
-    public override void AfterUpdate(in GameTime t)
+    public override void AfterExecute(in GameTime t)
     {
-        base.AfterUpdate(in t);
+        base.AfterExecute(in t);
         _batch.End();
     }
 }
 
 /// <summary>
-///     The debug system, shows how you can combine source generated queries and default ones. 
+///     The debug system, shows how you can combine source generated queries and default ones.
 /// </summary>
 public partial class DebugSystem : BaseSystem<World, GameTime>
 {
@@ -156,7 +156,7 @@ public partial class DebugSystem : BaseSystem<World, GameTime>
     private readonly QueryDescription _customQuery = new QueryDescription().WithAll<Position, Sprite>().WithNone<Velocity>();
 
     /// <summary>
-    ///     Creates a new <see cref="DebugSystem"/> instance. 
+    ///     Creates a new <see cref="DebugSystem"/> instance.
     /// </summary>
     /// <param name="world">The <see cref="World"/> used.</param>
     public DebugSystem(World world) : base(world)
@@ -165,10 +165,10 @@ public partial class DebugSystem : BaseSystem<World, GameTime>
     }
 
     /// <summary>
-    ///     Implements <see cref="BaseSystem{W,T}.Update"/> to call the custom Query and the source generated one. 
+    ///     Implements <see cref="BaseSystem{W,T}.Update"/> to call the custom Query and the source generated one.
     /// </summary>
     /// <param name="t">The <see cref="GameTime"/>.</param>
-    public override void Update(in GameTime t)
+    public override void Execute(in GameTime t)
     {
         World.Query(in _customQuery, entity => Console.WriteLine($"Custom : {entity}"));  // Manual query
         PrintEntitiesWithoutVelocityQuery(World);  // Call source generated query, which calls the PrintEntitiesWithoutVelocity method
@@ -180,7 +180,7 @@ public partial class DebugSystem : BaseSystem<World, GameTime>
     /// </summary>
     /// <param name="en">The <see cref="Entity"/>. Passed by the "PrintEntitiesWithoutVelocityQuery", you can also pass components or data parameters as usual.</param>
     [Query]
-    [All<Position, Sprite>, None<Velocity>]
+    [All(typeof(Position), typeof(Sprite)), None(typeof(Velocity))]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void PrintEntitiesWithoutVelocity(in Entity en)
     {
@@ -201,14 +201,14 @@ public partial class DebugSystem : BaseSystem<World, GameTime>
 }
 
 /// <summary>
-/// A event handler class using the source generated eventbus to intercept and react to events to decouple logic. 
+/// A event handler class using the source generated eventbus to intercept and react to events to decouple logic.
 /// </summary>
 public static partial class EventHandler
 {
 
     /// <summary>
     /// Listens for <see cref="ValueTuple{T1,T2}"/> events with a <see cref="World"/> and <see cref="KeyboardState"/> to check if the delte key was pressed.
-    /// If thats the case, it will remove the <see cref="Velocity"/> component from all of them. 
+    /// If thats the case, it will remove the <see cref="Velocity"/> component from all of them.
     /// </summary>
     /// <param name="tuple"></param>
     [Event(order: 1)]
@@ -216,8 +216,8 @@ public static partial class EventHandler
     public static void OnDeleteStopEntities(ref (World world, KeyboardState state) tuple)
     {
         if (!tuple.state.IsKeyDown(Keys.Delete)) return;
-        
-        // Query for velocity entities and remove their velocity to make them stop moving. 
+
+        // Query for velocity entities and remove their velocity to make them stop moving.
         var queryDesc = new QueryDescription().WithAll<Velocity>();
         tuple.world.Query(in queryDesc, entity => entity.Remove<Velocity>());
     }

--- a/Arch.System.SourceGenerator/QueryUtils.cs
+++ b/Arch.System.SourceGenerator/QueryUtils.cs
@@ -17,14 +17,14 @@ public static class QueryUtils
     /// <returns></returns>
     public static StringBuilder GetFirstElements(this StringBuilder sb, IEnumerable<IParameterSymbol> parameterSymbols)
     {
-      
+
         foreach (var symbol in parameterSymbols)
             if(symbol.Type.Name is not "Entity" || !symbol.GetAttributes().Any(data => data.AttributeClass!.Name.Contains("Data"))) // Prevent entity being added to the type array
                 sb.AppendLine($"ref var @{symbol.Type.Name.ToLower()}FirstElement = ref chunk.GetFirst<{symbol.Type.ToDisplayString(NullableFlowState.None, SymbolDisplayFormat.FullyQualifiedFormat)}>();");
 
         return sb;
     }
-    
+
     /// <summary>
     ///     Appends the components of the types specified in the <paramref name="parameterSymbols"/> from the previous specified first elements.
     /// </summary>
@@ -39,7 +39,7 @@ public static class QueryUtils
 
         return sb;
     }
-    
+
     /// <summary>
     ///     Inserts the types defined in the <paramref name="parameterSymbols"/> as parameters in a method.
     ///     <example>ref position, out velocity,...</example>
@@ -51,11 +51,11 @@ public static class QueryUtils
     {
         foreach (var symbol in parameterSymbols)
             sb.Append($"{CommonUtils.RefKindToString(symbol.RefKind)} @{symbol.Name.ToLower()},");
-        
+
         if(sb.Length > 0) sb.Length--;
         return sb;
     }
-    
+
     /// <summary>
     ///     Creates a ComponentType array from the <paramref name="parameterSymbols"/> passed through.
     /// </summary>
@@ -75,7 +75,7 @@ public static class QueryUtils
         foreach (var symbol in parameterSymbols)
             if(symbol.Name is not "Entity") // Prevent entity being added to the type array
                 sb.Append($"typeof({symbol.ToDisplayString(NullableFlowState.None, SymbolDisplayFormat.FullyQualifiedFormat)}),");
-        
+
         if (sb.Length > 0) sb.Length -= 1;
         sb.Append(')');
 
@@ -101,7 +101,7 @@ public static class QueryUtils
         sb.Length--;
         return sb;
     }
-    
+
     /// <summary>
     ///     Appends a set of <paramref name="parameterSymbols"/> if they are marked by the data attribute.
     ///     <example>ref gameTime, out somePassedList,...</example>
@@ -161,7 +161,7 @@ public static class QueryUtils
                 break;
             }
             data.Length--;
-            sb.AppendLine($"{method.Name}Query(World {data});");   
+            sb.AppendLine($"{method.Name}Query(World {data});");
         }
         return sb;
     }
@@ -207,8 +207,8 @@ public static class QueryUtils
         var anyAttributeData = methodSymbol.GetAttributeData("Any");
         var noneAttributeData = methodSymbol.GetAttributeData("None");
         var exclusiveAttributeData = methodSymbol.GetAttributeData("Exclusive");
-        
-        // Get params / components except those marked with data or entities. 
+
+        // Get params / components except those marked with data or entities.
         var components = methodSymbol.Parameters.ToList();
         components.RemoveAll(symbol => symbol.Type.Name.Equals("Entity"));                                                // Remove entitys 
         components.RemoveAll(symbol => symbol.GetAttributes().Any(data => data.AttributeClass!.Name.Contains("Data")));    // Remove data annotated params
@@ -219,7 +219,7 @@ public static class QueryUtils
         var noneArray = new List<ITypeSymbol>();
         var exclusiveArray = new List<ITypeSymbol>();
 
-        // Get All<...> or All(...) passed types and pass them to the arrays 
+        // Get All<...> or All(...) passed types and pass them to the arrays
         GetAttributeTypes(attributeData, allArray);
         GetAttributeTypes(anyAttributeData, anyArray);
         GetAttributeTypes(noneAttributeData, noneArray);
@@ -243,7 +243,7 @@ public static class QueryUtils
             IsGlobalNamespace = methodSymbol.ContainingNamespace.IsGlobalNamespace,
             Namespace = methodSymbol.ContainingNamespace.ToString(),
             ClassName = className.Substring(className.LastIndexOf('.')+1),
-            
+
             IsStatic = methodSymbol.IsStatic,
             IsEntityQuery = entity,
             MethodName = methodSymbol.Name,
@@ -251,7 +251,7 @@ public static class QueryUtils
             EntityParameter = entityParam!,
             Parameters = methodSymbol.Parameters,
             Components = components,
-            
+
             AllFilteredTypes = allArray,
             AnyFilteredTypes = anyArray,
             NoneFilteredTypes = noneArray,
@@ -270,19 +270,19 @@ public static class QueryUtils
     public static StringBuilder AppendQueryMethod(this StringBuilder sb, ref QueryMethod queryMethod)
     {
         var staticModifier = queryMethod.IsStatic ? "static" : "";
-        
-        // Generate code 
+
+        // Generate code
         var data = new StringBuilder().DataParameters(queryMethod.Parameters);
         var getFirstElements = new StringBuilder().GetFirstElements(queryMethod.Components);
         var getComponents = new StringBuilder().GetComponents(queryMethod.Components);
         var insertParams = new StringBuilder().InsertParams(queryMethod.Parameters);
-        
+
         var allTypeArray = new StringBuilder().GetTypeArray(queryMethod.AllFilteredTypes);
         var anyTypeArray = new StringBuilder().GetTypeArray(queryMethod.AnyFilteredTypes);
         var noneTypeArray = new StringBuilder().GetTypeArray(queryMethod.NoneFilteredTypes);
         var exclusiveTypeArray = new StringBuilder().GetTypeArray(queryMethod.ExclusiveFilteredTypes);
 
-        var template = 
+        var template =
             $$"""
             #nullable enable
             using System;
@@ -433,12 +433,12 @@ public static class QueryUtils
         var classSymbol = classToMethod.Key as INamedTypeSymbol;
 
         INamedTypeSymbol? parentSymbol = null;
-        var implementsUpdate = false;
+        var implementsExecute = false;
         var type = classSymbol;
         while (type != null)
         {
             // Update was implemented by user, no need to do that by source generator.
-            if (type.GetMembers("Update").OfType<IMethodSymbol>().Any(member => member.IsOverride))
+            if (type.GetMembers("Execute").OfType<IMethodSymbol>().Any(member => member.IsOverride))
                 implementsUpdate = true;
 
             type = type.BaseType;
@@ -451,7 +451,7 @@ public static class QueryUtils
             }
         }
 
-        if (parentSymbol == null || implementsUpdate)
+        if (parentSymbol == null || implementsExecute)
             return sb;
 
         // Get generic of BaseSystem
@@ -470,9 +470,9 @@ public static class QueryUtils
         };
         return sb.AppendBaseSystem(ref baseSystem);
     }
-    
+
     /// <summary>
-    ///     Adds a basesystem that calls a bunch of query methods. 
+    ///     Adds a basesystem that calls a bunch of query methods.
     /// </summary>
     /// <param name="sb">The <see cref="StringBuilder"/> instance.</param>
     /// <param name="baseSystem">The <see cref="BaseSystem"/> which is generated.</param>
@@ -489,7 +489,7 @@ public static class QueryUtils
                 partial class {{baseSystem.Name}}{
                         
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    public override void Update(in {{baseSystem.GenericType.ToDisplayString()}} data){
+                    public override void Execute(in {{baseSystem.GenericType.ToDisplayString()}} data){
                         {{methodCalls}}
                     }
                 }

--- a/Arch.System.SourceGenerator/SourceGenerator.cs
+++ b/Arch.System.SourceGenerator/SourceGenerator.cs
@@ -21,7 +21,21 @@ public class QueryGenerator : IIncrementalGenerator
     {
         //if (!Debugger.IsAttached) Debugger.Launch();
 
-        // Do a simple filter for methods marked with update
+        // Register the generic attributes
+        var attributes = $$"""
+            namespace Arch.System.SourceGenerator
+            {
+            #if NET7_0_OR_GREATER
+                {{new StringBuilder().AppendGenericAttributes("All", "All", 25)}}
+                {{new StringBuilder().AppendGenericAttributes("Any", "Any", 25)}}
+                {{new StringBuilder().AppendGenericAttributes("None", "None", 25)}}
+                {{new StringBuilder().AppendGenericAttributes("Exclusive", "Exclusive", 25)}}
+            #endif
+            }
+        """;
+        context.RegisterPostInitializationOutput(ctx => ctx.AddSource("Attributes.g.cs", SourceText.From(attributes, Encoding.UTF8)));
+
+        // Do a simple filter for methods marked with execute
         IncrementalValuesProvider<MethodDeclarationSyntax> methodDeclarations = context.SyntaxProvider.CreateSyntaxProvider(
                  static (s, _) => s is MethodDeclarationSyntax { AttributeLists.Count: > 0 },
                  static (ctx, _) => GetMethodSymbolIfAttributeof(ctx, "Arch.System.QueryAttribute")
@@ -46,7 +60,7 @@ public class QueryGenerator : IIncrementalGenerator
         }
         list.Add(methodSymbol);
     }
-    
+
     /// <summary>
     ///     Returns a <see cref="MethodDeclarationSyntax"/> if it's annotated with an attribute of <paramref name="name"/>.
     /// </summary>
@@ -64,7 +78,7 @@ public class QueryGenerator : IIncrementalGenerator
             foreach (var attributeSyntax in attributeListSyntax.Attributes)
             {
                 if (ModelExtensions.GetSymbolInfo(context.SemanticModel, attributeSyntax).Symbol is not IMethodSymbol attributeSymbol) continue;
-                
+
                 var attributeContainingTypeSymbol = attributeSymbol.ContainingType;
                 var fullName = attributeContainingTypeSymbol.ToDisplayString();
 
@@ -87,7 +101,7 @@ public class QueryGenerator : IIncrementalGenerator
     private static void Generate(Compilation compilation, ImmutableArray<MethodDeclarationSyntax> methods, SourceProductionContext context)
     {
         if (methods.IsDefaultOrEmpty) return;
-        
+
         // Generate Query methods and map them to their classes
         _classToMethods = new(512, SymbolEqualityComparer.Default);
         foreach (var methodSyntax in methods)
@@ -125,7 +139,7 @@ public class QueryGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Compares <see cref="MethodDeclarationSyntax"/>s to remove duplicates. 
+    /// Compares <see cref="MethodDeclarationSyntax"/>s to remove duplicates.
     /// </summary>
     class Comparer : IEqualityComparer<MethodDeclarationSyntax>
     {

--- a/Arch.System/Systems.cs
+++ b/Arch.System/Systems.cs
@@ -14,7 +14,7 @@ using System.Diagnostics.Metrics;
 namespace Arch.System;
 
 /// <summary>
-///     An interface providing several methods for a system. 
+///     An interface providing several methods for a system.
 /// </summary>
 /// <typeparam name="T">The type passed to each method. For example a delta time or some other data.</typeparam>
 public interface ISystem<T> : IDisposable
@@ -23,24 +23,24 @@ public interface ISystem<T> : IDisposable
     ///     Initializes a system, before its first ever run.
     /// </summary>
     void Initialize();
-    
+
     /// <summary>
-    ///     Runs before <see cref="Update"/>.
+    ///     Runs before <see cref="Execute"/>.
     /// </summary>
     /// <param name="t">An instance passed to it.</param>
-    void BeforeUpdate(in T t);
-    
+    void BeforeExecute(in T t);
+
     /// <summary>
     ///     Updates the system.
     /// </summary>
     /// <param name="t">An instance passed to it.</param>
-    void Update(in T t);
-    
+    void Execute(in T t);
+
     /// <summary>
-    ///     Runs after <see cref="Update"/>.
+    ///     Runs after <see cref="Execute"/>.
     /// </summary>
     /// <param name="t">An instance passed to it.</param>
-    void AfterUpdate(in T t);
+    void AfterExecute(in T t);
 }
 
 /// <summary>
@@ -50,18 +50,18 @@ public interface ISystem<T> : IDisposable
 /// <typeparam name="T">The type passed to the <see cref="ISystem{T}"/> interface.</typeparam>
 public abstract class BaseSystem<W, T> : ISystem<T>
 {
-    
+
     /// <summary>
-    ///     Creates an instance. 
+    ///     Creates an instance.
     /// </summary>
     /// <param name="world">The <see cref="World"/>.</param>
     protected BaseSystem(W world)
     {
         World = world;
     }
- 
+
     /// <summary>
-    ///     The world instance. 
+    ///     The world instance.
     /// </summary>
     public W World { get; private set; }
 
@@ -69,13 +69,13 @@ public abstract class BaseSystem<W, T> : ISystem<T>
     public virtual void Initialize(){}
 
     /// <inheritdoc />
-    public virtual void BeforeUpdate(in T t) { }
+    public virtual void BeforeExecute(in T t) { }
 
     /// <inheritdoc />
-    public virtual void Update(in T t){}
+    public virtual void Execute(in T t){}
 
     /// <inheritdoc />
-    public virtual void AfterUpdate(in T t){}
+    public virtual void AfterExecute(in T t){}
 
     /// <inheritdoc />
     public virtual void Dispose(){}
@@ -99,7 +99,7 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
     public string Name { get; }
 
     /// <summary>
-    /// All <see cref="SystemEntry"/>'s in this group. 
+    /// All <see cref="SystemEntry"/>'s in this group.
     /// </summary>
     private readonly List<SystemEntry> _systems = new();
 
@@ -150,7 +150,7 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
 
         return this;
     }
-    
+
     /// <summary>
     ///     Adds an single <see cref="ISystem{T}"/> to this group by its generic.
     ///     Automatically initializes it properly. Must be contructorless.
@@ -202,7 +202,7 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
 
         return default;
     }
-    
+
     /// <summary>
     ///     Finds all <see cref="ISystem{T}"/>s which can be cast into the given type.
     /// </summary>
@@ -221,10 +221,10 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
             {
                 continue;
             }
-            
+
             foreach (var nested in grp.Find<G>())
             {
-                yield return nested;   
+                yield return nested;
             }
         }
     }
@@ -242,10 +242,10 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
     }
 
     /// <summary>
-    ///     Runs <see cref="ISystem{T}.BeforeUpdate"/> on each <see cref="ISystem{T}"/> of this <see cref="Group{T}"/>..
+    ///     Runs <see cref="ISystem{T}.BeforeExecute"/> on each <see cref="ISystem{T}"/> of this <see cref="Group{T}"/>..
     /// </summary>
     /// <param name="t">An instance passed to each <see cref="ISystem{T}.Initialize"/> method.</param>
-    public void BeforeUpdate(in T t)
+    public void BeforeExecute(in T t)
     {
         for (var index = 0; index < _systems.Count; index++)
         {
@@ -256,21 +256,21 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
             {
 #endif
 
-                entry.System.BeforeUpdate(in t);
+                entry.System.BeforeExecute(in t);
 
 #if !ARCH_METRICS_DISABLED
             }
             _timer.Stop();
-            entry.BeforeUpdate.Record(_timer.Elapsed.TotalMilliseconds);
+            entry.BeforeExecute.Record(_timer.Elapsed.TotalMilliseconds);
 #endif
         }
     }
 
     /// <summary>
-    ///     Runs <see cref="ISystem{T}.Update"/> on each <see cref="ISystem{T}"/> of this <see cref="Group{T}"/>..
+    ///     Runs <see cref="ISystem{T}.Execute"/> on each <see cref="ISystem{T}"/> of this <see cref="Group{T}"/>..
     /// </summary>
     /// <param name="t">An instance passed to each <see cref="ISystem{T}.Initialize"/> method.</param>
-    public void Update(in T t)
+    public void Execute(in T t)
     {
         for (var index = 0; index < _systems.Count; index++)
         {
@@ -281,21 +281,21 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
             {
 #endif
 
-                entry.System.Update(in t);
+                entry.System.Execute(in t);
 
 #if !ARCH_METRICS_DISABLED
             }
             _timer.Stop();
-            entry.Update.Record(_timer.Elapsed.TotalMilliseconds);
+            entry.Execute.Record(_timer.Elapsed.TotalMilliseconds);
 #endif
         }
     }
 
     /// <summary>
-    ///     Runs <see cref="ISystem{T}.AfterUpdate"/> on each <see cref="ISystem{T}"/> of this <see cref="Group{T}"/>..
+    ///     Runs <see cref="ISystem{T}.AfterExecute"/> on each <see cref="ISystem{T}"/> of this <see cref="Group{T}"/>..
     /// </summary>
     /// <param name="t">An instance passed to each <see cref="ISystem{T}.Initialize"/> method.</param>
-    public void AfterUpdate(in T t)
+    public void AfterExecute(in T t)
     {
         for (var index = 0; index < _systems.Count; index++)
         {
@@ -306,12 +306,12 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
             {
 #endif
 
-                entry.System.AfterUpdate(in t);
+                entry.System.AfterExecute(in t);
 
 #if !ARCH_METRICS_DISABLED
             }
             _timer.Stop();
-            entry.AfterUpdate.Record(_timer.Elapsed.TotalMilliseconds);
+            entry.AfterExecute.Record(_timer.Elapsed.TotalMilliseconds);
 #endif
         }
     }
@@ -345,7 +345,7 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
         {
             stringBuilder.Length--;
         }
-        
+
         return $"Group = {{ {nameof(Name)} = {Name}, Systems = {{ {stringBuilder} }} }} ";
     }
     
@@ -372,9 +372,9 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
         public readonly ISystem<T> System;
 
 #if !ARCH_METRICS_DISABLED
-        public readonly Histogram<double> BeforeUpdate;
-        public readonly Histogram<double> Update;
-        public readonly Histogram<double> AfterUpdate;
+        public readonly Histogram<double> BeforeExecute;
+        public readonly Histogram<double> Execute;
+        public readonly Histogram<double> AfterExecute;
 #endif
 
         public void Dispose()
@@ -392,9 +392,9 @@ public class Group<T> : ISystem<T>, IEnumerable<ISystem<T>>
             System = system;
 
 #if !ARCH_METRICS_DISABLED
-            BeforeUpdate = meter.CreateHistogram<double>($"{name}.BeforeUpdate", unit: "millisecond");
-            Update = meter.CreateHistogram<double>($"{name}.Update", unit: "millisecond");
-            AfterUpdate = meter.CreateHistogram<double>($"{name}.AfterUpdate", unit: "millisecond");
+            BeforeExecute = meter.CreateHistogram<double>($"{name}.BeforeExecute", unit: "millisecond");
+            Execute = meter.CreateHistogram<double>($"{name}.Execute", unit: "millisecond");
+            AfterExecute = meter.CreateHistogram<double>($"{name}.AfterExecute", unit: "millisecond");
 #endif
         }
     }


### PR DESCRIPTION
Hello, this PR is aimed at several different areas to make the features available in `Arch.Extended` more compatible with Unity and easier for developers to build and use.

I've based this PR on https://github.com/genaray/Arch.Extended/pull/67 so I'd hold off on merging it if there are any concerns/issues with that one.

## Publish Profiles

I've created publish profiles for all the non-tests/sample projects with the correct settings such that a developer has a straightforward path to publish these projects and use them in Unity without compiler error issues. The steps are to:

1. Publish each project using the provided profile. This will result in all assemblies being published to two folders underneath `UnityPublish`.

* `UnityPublish`
    * `Plugins` => Contains assemblies that may need to be directly referenced.
    * `SourceGenerators` => Contains source generator assemblies only. These require a few special steps after being imported into Unity to use properly.

2. Import the contents of `UnityPublish` into a folder in Unity. This will cause compiler errors temporarily due to the source generators.
3. Select all assemblies underneath `SourceGenerators` and make sure the following settings are configured.
    * Go to Select platforms for plugin and disable Any Platform.
    * Go to Include Platforms and disable Editor and Standalone.
    * Go to Asset Labels and open the Asset Labels sub-menu (this is present in the lower-right corner of the inspector). 
    * Assign a custom `RoslynAnalyzers` label to all of them.

![image](https://github.com/genaray/Arch.Extended/assets/1663648/5495bf83-9eaa-443b-b4fd-2747ba11cd1b)

![image](https://github.com/genaray/Arch.Extended/assets/1663648/c9c3cb99-ae1a-4e5d-8340-9495cfcb56ae)

4. This should result in all compiler errors going away and all features of Arch.Extended can be used in Unity.

If useful these instructions could be added to the Wiki.

## AOT.SourceGenerator

Unity's C# level and capabilities do not currently include `[ModuleInitializer]` and so this source generator did not work in Unity as a result as well as causing compiler errors. I've modified this to conditionally use the Unity equivalent `[RuntimeInitializeOnLoadMethod]` instead when this source generator is used in Unity projects.

I also added a small QOL debug change to sort the component types by name; this makes it easier to visually inspect the generated code in the case of any issues.

## Systems

This is a helpful feature that almost seems like it could be a default for Arch, but has one issue that currently makes that impossible to use in Unity with `MonoBehavior` and `ScriptableObject` types. 

`Update()` is a special method in Unity for anything derived from MonoBehavior or ScriptableObject, even if it includes parameters. Attempting to use overloads of `Update()` on these types will result in Unity crashing, which prevents developers from being able to implement `ISystem<T>` on these types.

This PR changes these methods to instead use `Execute` in place of `Update` which fixes this issue and updates the sample project as a result. This enabled me as a developer to make a few Unity-centric base classes for systems so that I could create `ScriptableObject`, `MonoBehavior`, and even third-party `MonoBehavior` derived systems and does not result in Unity Editor crashes.

**`ScriptableObject` Examples of Systems**

![image](https://github.com/genaray/Arch.Extended/assets/1663648/226dc042-35c3-422a-854c-ef9a8867bb21)

**`MonoBehavior` Examples of Systems**
![image](https://github.com/genaray/Arch.Extended/assets/1663648/0f945094-45f9-4b5f-84b3-84fe3d0eda83)

@genaray The only issue with this change from `Update` to `Execute` is that it would be a breaking API change and perhaps not necessarily one we'd want to force on everybody for the sake of just Unity developers. I could also instead rework this to conditionally use `Execute` over `Update` if something like a `Unity` constant were added to both System projects, but then this would result in the locally included sample project to fail to compile when a Unity developer locally made those changes. Any thoughts on how you would like to accept changes like these that aim for compatibility with specific engines?