### PR TITLE
Fix NRT warning in source generator.

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -260,7 +260,7 @@ public static class QueryUtils
                         Exclusive = {{exclusiveTypeArray}}
                     };
 
-                    private {{staticModifier}} World? _{{queryMethod.MethodName}}_Initialized;
+                    private {{staticModifier}} World _{{queryMethod.MethodName}}_Initialized;
                     private {{staticModifier}} Query _{{queryMethod.MethodName}}_Query;
 
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Fixes the issue raised in #69.

As it turns out I did not fully understand how NRT works in source generated files.
Aparently the default behaviour for generated code is essentially to have NRT disabled, and must be manually enabled using `#nullable enable` in the generated code.

In the case of `Query.cs` the generated code does not need NRT enabled so instead of adding `#nullable enable`, I have simply removed the nullable annotation. I have tested this change on projects with NRT enable and disabled, and it works as intended and fixes the warning.