### PR TITLE
Add group name to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ public class Game
         // Create a world and a group of systems which will be controlled 
         var world = World.Create();
         var _systems = new Group<float>(
+            "Systems",
             new MovementSystem(world),   // Run in order
             new MyOtherSystem(...),
             ...


### PR DESCRIPTION
Hi!

Tiny tweak to the readme - noticed that it doesn't match the game sample
Got stuck for a bit as I wasn't sure if I was just missing an extension ref or something
https://github.com/genaray/Arch.Extended/blob/master/Arch.Extended.Sample/Game.cs