### PR TITLE
SourceGenerator: Improve detection of overridden Update methods

### DIFF
--- a/Arch.System.SourceGenerator/Query.cs
+++ b/Arch.System.SourceGenerator/Query.cs
@@ -438,7 +438,7 @@ public static class QueryUtils
         while (type != null)
         {
             // Update was implemented by user, no need to do that by source generator.
-            if (type.MemberNames.Contains("Update"))
+            if (type.GetMembers("Update").OfType<IMethodSymbol>().Any(member => member.IsOverride))
                 implementsUpdate = true;
 
             type = type.BaseType;


### PR DESCRIPTION
This PR resolves issue #86 by refining the logic within QueryUtils.AppendBaseSystem used to detect existing implementations of the Update method.

Previously, the detection relied solely on method names, causing incorrect identification of methods not properly marked as override or methods with incorrect signatures. This led the generator to skip emitting the required Update method implementations, potentially resulting missing behavior.

The updated approach implements a minimal yet effective check:

```csharp
implementsUpdate = type.GetMembers("Update").OfType<IMethodSymbol>().Any(member => member.IsOverride);
```

This ensures only methods explicitly marked with the override keyword are detected, significantly reducing false positives while maintaining readability and performance.

## Fixes #86

Related issue: https://github.com/genaray/Arch.Extended/issues/86
