### PR TITLE
Update AOT extension to be compatible with Arch 2.1.0

### DIFF
--- a/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
+++ b/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
@@ -17,7 +17,7 @@
         <Authors>genaray</Authors>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <Description>A source generator for arch to support AOT. </Description>
-        <PackageReleaseNotes>Updated to Arch 1.7 and up. </PackageReleaseNotes>
+        <PackageReleaseNotes>Updated to Arch 2.1.0 </PackageReleaseNotes>
         <PackageTags>c#;.net;.net6;.net7;ecs;game;entity;gamedev; game-development; game-engine; entity-component-system; arch;</PackageTags>
 
         <PackageProjectUrl>https://github.com/genaray/Arch.Extended</PackageProjectUrl>

--- a/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class StringBuilderExtensions
 		sb.AppendLine(
 			$$"""
 		    using System.Runtime.CompilerServices;
-		    using Arch.Core.Utils;
+		    using Arch.Core;
 		              
 		    namespace Arch.AOT.SourceGenerator
 		    {


### PR DESCRIPTION
A small fix to point to the new location of `ArrayRegistry`