### PR TITLE
AOT: Support registering generic components

### DIFF
--- a/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
+++ b/Arch.AOT.SourceGenerator/Arch.AOT.SourceGenerator.csproj
@@ -13,7 +13,7 @@
 
         <PackageId>Arch.AOT.SourceGenerator</PackageId>
         <Title>Arch.AOT.SourceGenerator</Title>
-        <Version>1.0.1</Version>
+        <Version>1.0.3-custom</Version>
         <Authors>genaray</Authors>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <Description>A source generator for arch to support AOT. </Description>

--- a/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class StringBuilderExtensions
 		sb.AppendLine(
 			$$"""
 		    using System.Runtime.CompilerServices;
-		    using Arch.Core.Utils;
+		    using Arch.Core;
 		              
 		    namespace Arch.AOT.SourceGenerator
 		    {


### PR DESCRIPTION
This fixes an issue/limitation of the Component Registry generator, where generic components were being registered directly instead of registering the concrete types derived from it. We encountered this in our own project.

Before:
```csharp
[ModuleInitializer]
        public static void Initialize()
        {
           ArrayRegistry.Add<Events<T>>();
           ArrayRegistry.Add<DespawnOn<T>>();
        }
````
This caused a compilation error.

After:
```csharp
[ModuleInitializer]
        public static void Initialize()
        {
            ArrayRegistry.Add<DespawnOn<CollisionEvent>>();
            ArrayRegistry.Add<DespawnOn<DamageEvent>>();
            ArrayRegistry.Add<Events<CollisionEvent>>();
        }
```

The concrete types don't need to be manually registered, the generator automatically scans for them.