### PR TITLE
EntityData.Version not serialized

### DIFF
--- a/Arch.Persistence.Tests/PersistenceTest.cs
+++ b/Arch.Persistence.Tests/PersistenceTest.cs
@@ -158,8 +158,50 @@ public class Tests
 
         var newWorld = World.Create();
         var newEntity = _jsonSerializer.Deserialize(newWorld, bytes);
-        
+
         That(newEntity.Get<Transform>(), Is.EqualTo(entity.Get<Transform>()));
         That(newEntity.Get<MetaData>(), Is.EqualTo(entity.Get<MetaData>()));
+    }
+
+    /// <summary>
+    ///     Checks if entities are alive after binary world deserialization.
+    ///     This verifies that EntityData.Version is correctly preserved.
+    /// </summary>
+    [Test]
+    public void BinaryWorldSerialization_EntitiesAreAlive()
+    {
+        var bytes = _binarySerializer.Serialize(_world);
+        var newWorld = _binarySerializer.Deserialize(bytes);
+
+        var newEntities = new Entity[newWorld.Size];
+        newWorld.GetEntities(new QueryDescription(), newEntities.AsSpan());
+
+        // All entities should be alive after deserialization
+        for (var index = 0; index < newEntities.Length; index++)
+        {
+            var entity = newEntities[index];
+            That(newWorld.IsAlive(entity), Is.True, $"Entity {entity.Id} with version {entity.Version} should be alive");
+        }
+    }
+
+    /// <summary>
+    ///     Checks if entities are alive after JSON world deserialization.
+    ///     This verifies that EntityData.Version is correctly preserved.
+    /// </summary>
+    [Test]
+    public void JsonWorldSerialization_EntitiesAreAlive()
+    {
+        var bytes = _jsonSerializer.Serialize(_world);
+        var newWorld = _jsonSerializer.Deserialize(bytes);
+
+        var newEntities = new Entity[newWorld.Size];
+        newWorld.GetEntities(new QueryDescription(), newEntities.AsSpan());
+
+        // All entities should be alive after deserialization
+        for (var index = 0; index < newEntities.Length; index++)
+        {
+            var entity = newEntities[index];
+            That(newWorld.IsAlive(entity), Is.True, $"Entity {entity.Id} with version {entity.Version} should be alive");
+        }
     }
 }

--- a/Arch.Persistence/Binary.cs
+++ b/Arch.Persistence/Binary.cs
@@ -269,17 +269,23 @@ public partial class EntitySlotFormatter : IMessagePackFormatter<EntityData>
 
         // Write entity index
         writer.WriteUInt32((uint)value.Slot.Index);
+
+        // Write version (required for IsAlive checks after deserialization)
+        writer.WriteInt32(value.Version);
     }
 
     /// <inheritdoc cref="IMessagePackFormatter{T}.Deserialize"/>
     public EntityData Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
     {
-        
+
         // Read chunk index and entity index
         var chunkIndex = reader.ReadUInt32();
         var entityIndex = reader.ReadUInt32();
 
-        return new EntityData(null!, new Slot((int)entityIndex, (int)chunkIndex), 0);
+        // Read version (required for IsAlive checks after deserialization)
+        var version = reader.ReadInt32();
+
+        return new EntityData(null!, new Slot((int)entityIndex, (int)chunkIndex), version);
     }
 }
 

--- a/Arch.Persistence/Json.cs
+++ b/Arch.Persistence/Json.cs
@@ -403,7 +403,7 @@ public partial class EntitySlotFormatter : IJsonFormatter<EntityData>
     public void Serialize(ref JsonWriter writer, EntityData value, IJsonFormatterResolver options)
     {
         writer.WriteBeginObject();
-        
+
         // Write chunk index
         writer.WritePropertyName("chunkIndex");
         writer.WriteUInt32((uint)value.Slot.ChunkIndex);
@@ -412,7 +412,12 @@ public partial class EntitySlotFormatter : IJsonFormatter<EntityData>
         // Write entity index
         writer.WritePropertyName("index");
         writer.WriteUInt32((uint)value.Slot.Index);
-        
+        writer.WriteValueSeparator();
+
+        // Write version (required for IsAlive checks after deserialization)
+        writer.WritePropertyName("version");
+        writer.WriteInt32(value.Version);
+
         writer.WriteEndObject();
     }
 
@@ -425,13 +430,18 @@ public partial class EntitySlotFormatter : IJsonFormatter<EntityData>
         reader.ReadPropertyName();
         var chunkIndex = reader.ReadUInt32();
         reader.ReadIsValueSeparator();
-        
+
         // Read entity index
         reader.ReadPropertyName();
         var entityIndex = reader.ReadUInt32();
+        reader.ReadIsValueSeparator();
+
+        // Read version (required for IsAlive checks after deserialization)
+        reader.ReadPropertyName();
+        var version = reader.ReadInt32();
 
         reader.ReadIsEndObject();
-        return new EntityData(null!, new Slot((int)entityIndex, (int)chunkIndex), 0);
+        return new EntityData(null!, new Slot((int)entityIndex, (int)chunkIndex), version);
     }
 }
 


### PR DESCRIPTION
I ran into an issue with de-serialization where all the entities that were re-loaded into the world were failing isAlive checks and breaking code that utilizes it. Looking into it, it seems like the version is being reset and not serialized which then breaks isAlive?

I could be wrong in my approach as i don't understand the library all that well only just getting into ECS, but i thought i would submit the test case and a fix which im not really sure is warranted but seems to fix the test case and ill probably use for my own project for now as it seems to fix the issue for me.