### PR TITLE
Fix ArrayRegistry declaration

### DIFF
--- a/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/Arch.AOT.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class StringBuilderExtensions
 			$$"""
 		    using System.Runtime.CompilerServices;
 		    using Arch.Core.Utils;
+		    using Arch.Core;
 		              
 		    namespace Arch.AOT.SourceGenerator
 		    {


### PR DESCRIPTION
Added 'using' directive in source generator content to ensure ArrayRegistry declaration works correctly.